### PR TITLE
Add inner RotData loop support

### DIFF
--- a/NuMagSANS/NuMagSANS.py
+++ b/NuMagSANS/NuMagSANS.py
@@ -100,6 +100,7 @@ class NuMagSANS:
         RotDataLoop=0,
         RotDataLoop_From=1,
         RotDataLoop_To=1,
+        RotData_User_Selection=None,
         User_Selection=[1],
 
         # units
@@ -183,6 +184,8 @@ class NuMagSANS:
             W("RotDataLoop", RotDataLoop)
             W("RotDataLoop_From", RotDataLoop_From)
             W("RotDataLoop_To", RotDataLoop_To)
+            if RotData_User_Selection is not None:
+                W("RotData_User_Selection", "{" + ", ".join(map(str, RotData_User_Selection)) + "}")
             W("User_Selection", "{" + ", ".join(map(str, User_Selection)) + "}")
 
             # ---------------------------

--- a/NuMagSANS/NuMagSANS.py
+++ b/NuMagSANS/NuMagSANS.py
@@ -79,6 +79,7 @@ class NuMagSANS:
         MagDataPath="RealSpaceData/MagData",
         StructDataFilename="RealSpaceData/StructData.csv",
         RotDataFilename="RealSpaceData/RotData.csv",
+        RotDataPath="RealSpaceData/RotData",
         foldernameSANSData="NuMagSANS_Output",
 
         # selection
@@ -96,6 +97,9 @@ class NuMagSANS:
         Loop_Modus=0,
         Loop_From=1,
         Loop_To=20,
+        RotDataLoop=0,
+        RotDataLoop_From=1,
+        RotDataLoop_To=1,
         User_Selection=[1],
 
         # units
@@ -152,6 +156,7 @@ class NuMagSANS:
             W("MagDataPath", MagDataPath)
             W("StructDataFilename", StructDataFilename)
             W("RotDataFilename", RotDataFilename)
+            W("RotDataPath", RotDataPath)
             W("foldernameSANSData", foldernameSANSData)
 
             # ---------------------------
@@ -175,6 +180,9 @@ class NuMagSANS:
             W("Loop_Modus", Loop_Modus)
             W("Loop_From", Loop_From)
             W("Loop_To", Loop_To)
+            W("RotDataLoop", RotDataLoop)
+            W("RotDataLoop_From", RotDataLoop_From)
+            W("RotDataLoop_To", RotDataLoop_To)
             W("User_Selection", "{" + ", ".join(map(str, User_Selection)) + "}")
 
             # ---------------------------

--- a/docs/GettingStarted/ParameterOverview.rst
+++ b/docs/GettingStarted/ParameterOverview.rst
@@ -334,6 +334,54 @@ written as
         q \cos\theta
     \end{bmatrix}.
 
+The magnetic SANS amplitudes are expressed through the Halpern-Johnson vector
+:math:`\widetilde{\mathbf{Q}}`, i.e. the component of the Fourier-transformed
+magnetization that contributes to magnetic neutron scattering:
+
+.. math::
+
+    \widetilde{\mathbf{Q}}
+    =
+    \hat{\mathbf{q}}
+    \left(\hat{\mathbf{q}}\cdot\widetilde{\mathbf{M}}\right)
+    -
+    \widetilde{\mathbf{M}},
+
+with
+
+.. math::
+
+    \hat{\mathbf{q}}
+    =
+    \begin{bmatrix}
+        0 \\
+        \sin\theta \\
+        \cos\theta
+    \end{bmatrix},
+    \qquad
+    \widetilde{\mathbf{M}}
+    =
+    \begin{bmatrix}
+        \widetilde{M}_x \\
+        \widetilde{M}_y \\
+        \widetilde{M}_z
+    \end{bmatrix}.
+
+For the detector geometry used in NuMagSANS this gives
+
+.. math::
+
+    \widetilde{\mathbf{Q}}
+    =
+    \begin{bmatrix}
+        -\widetilde{M}_x \\
+        \left(\widetilde{M}_z\sin\theta-\widetilde{M}_y\cos\theta\right)\cos\theta \\
+        \left(\widetilde{M}_y\cos\theta-\widetilde{M}_z\sin\theta\right)\sin\theta
+    \end{bmatrix}.
+
+The same expression is applied to the real and imaginary parts of
+:math:`\widetilde{\mathbf{M}}` in the atomistic kernels.
+
 In NuMagSANS the 2D SANS cross sections are exported in units of :math:`\mathrm{cm}^{-1}`.
 
 ``Nuclear_2D``

--- a/docs/GettingStarted/ParameterOverview.rst
+++ b/docs/GettingStarted/ParameterOverview.rst
@@ -75,7 +75,7 @@ NuMagSANS separates local object data from optional assembly metadata:
      - ``StructData.csv``
    * - ``RotData``
      - Object-wise local rotations. One row per object with ZYZ Euler angles ``alpha beta gamma`` in radians.
-     - ``RotData.csv``
+     - ``RotData.csv`` or ``RotData/RotData_1.csv``, ``RotData/RotData_2.csv``, ...
 
 This separation allows several system types to be represented with the same
 backend: fully materialized micromagnetic or atomistic datasets can be imported
@@ -111,6 +111,13 @@ local object data without rewriting the object files.
     The file must contain one row per object and three columns:
     ``alpha beta gamma``. The convention is
     :math:`R = R_z(\alpha) R_y(\beta) R_z(\gamma)`, with angles in radians.
+
+``RotDataPath``
+    Default path ``RealSpaceData/RotData``
+
+    Folder used by ``RotDataLoop``. In this mode, rotation files are expected
+    to follow the naming convention ``RotData_1.csv``, ``RotData_2.csv``, ...
+    inside ``RotDataPath``. Each file contains one object-wise rotation table.
 
 ``foldernameSANSData``
     Default ``NuMagSANS_Output``
@@ -198,6 +205,34 @@ These parameters control batch simulations or repeated calculations.
     If ``Loop_Modus = 0``, only the listed file indices are evaluated. If
     ``Loop_Modus = 1``, the index range from ``Loop_From`` to ``Loop_To`` is
     used.
+
+``RotDataLoop``
+    Description: Enable an inner loop over several rotation-data files.
+    Default ``0``
+
+    If ``RotDataLoop = 1``, NuMagSANS loads the selected ``RotData_#.csv``
+    files from ``RotDataPath`` while keeping the currently selected magnetic,
+    nuclear, and structure data fixed. This is useful for evaluating the same
+    local object data under multiple object-wise rotation configurations.
+
+``RotDataLoop_From``
+    Description: First rotation-data file index used by the inner RotData loop.
+    Default ``1``
+
+``RotDataLoop_To``
+    Description: Last rotation-data file index used by the inner RotData loop.
+    Default ``1``
+
+``RotData_User_Selection``
+    Description: Optional explicit list of selected rotation-data file indices.
+
+    If this option is present, it selects the exact ``RotData_#.csv`` files
+    used by the inner RotData loop, for example ``{1, 3, 4}``. If it is not
+    present, the contiguous range from ``RotDataLoop_From`` to
+    ``RotDataLoop_To`` is used.
+
+    For a fixed data-file index and a selected rotation-data index, output is
+    written to a nested folder such as ``SANS_1/RotData_3/``.
 
 Constant Parameters
 -------------------

--- a/examples/example1/GenerateRealSpaceData.py
+++ b/examples/example1/GenerateRealSpaceData.py
@@ -1,0 +1,174 @@
+"""Generate the RealSpaceData input set for NuMagSANS example 1.
+
+The example uses five identical local spherical magnetic objects and places
+them through ``StructData.csv``. Each local object folder contains six data
+files so the existing ``User_Selection`` indices can select equivalent test
+datasets without storing them manually in the repository.
+
+All CSV files are written without headers and with whitespace separators,
+matching the NuMagSANS real-space input format.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import argparse
+import shutil
+
+import numpy as np
+
+
+BASE_DIR = Path(__file__).resolve().parent
+REAL_SPACE_DIR = BASE_DIR / "RealSpaceData"
+
+DEFAULT_OBJECT_CENTERS = np.array(
+    [
+        (0.0, 0.0, 0.0),
+        (10.0, 0.0, 0.0),
+        (0.0, 10.0, 0.0),
+        (0.0, 0.0, 10.0),
+        (20.0, 0.0, 0.0),
+    ],
+    dtype=float,
+)
+
+
+def sample_spherical_grid(radius: float, spacing: float, points_per_axis: int) -> np.ndarray:
+    """Return cubic-grid points clipped by a sphere centered at the origin."""
+
+    if points_per_axis < 1:
+        raise ValueError("points_per_axis must be at least 1.")
+
+    if points_per_axis % 2 == 0:
+        raise ValueError("points_per_axis must be odd so the grid contains the origin.")
+
+    half_width = points_per_axis // 2
+    axis = (np.arange(points_per_axis, dtype=float) - half_width) * spacing
+    x_grid, y_grid, z_grid = np.meshgrid(axis, axis, axis, indexing="ij")
+    mask = x_grid**2 + y_grid**2 + z_grid**2 <= radius**2
+    positions = np.column_stack((x_grid[mask], y_grid[mask], z_grid[mask]))
+    order = np.lexsort((positions[:, 1], positions[:, 0], positions[:, 2]))
+    return positions[order]
+
+
+def write_struct_data(real_space_dir: Path, object_centers: np.ndarray) -> None:
+    """Write the global object-center positions."""
+
+    np.savetxt(real_space_dir / "StructData.csv", object_centers, fmt="%.10g", delimiter=" ")
+
+
+def write_magnetic_data(
+    real_space_dir: Path,
+    local_positions: np.ndarray,
+    magnetization: tuple[float, float, float],
+    n_objects: int,
+    n_datasets: int,
+) -> None:
+    """Write local magnetic object files as x y z mx my mz."""
+
+    mag_dir = real_space_dir / "MagData"
+    moment_rows = np.repeat(np.asarray(magnetization, dtype=float)[None, :], len(local_positions), axis=0)
+    magnetic_data = np.column_stack((local_positions, moment_rows))
+
+    for object_index in range(1, n_objects + 1):
+        object_dir = mag_dir / f"Angle_{object_index}"
+        object_dir.mkdir(parents=True, exist_ok=True)
+
+        for dataset_index in range(1, n_datasets + 1):
+            np.savetxt(
+                object_dir / f"m_{dataset_index}.csv",
+                magnetic_data,
+                fmt="%.10g",
+                delimiter=" ",
+            )
+
+
+def write_nuclear_data(
+    real_space_dir: Path,
+    local_positions: np.ndarray,
+    nuclear_sld: float,
+    n_objects: int,
+    n_datasets: int,
+) -> None:
+    """Write local nuclear object files as x y z rho."""
+
+    nuc_dir = real_space_dir / "NucData"
+    sld_rows = np.full((len(local_positions), 1), nuclear_sld, dtype=float)
+    nuclear_data = np.column_stack((local_positions, sld_rows))
+
+    for object_index in range(1, n_objects + 1):
+        object_dir = nuc_dir / f"Angle_{object_index}"
+        object_dir.mkdir(parents=True, exist_ok=True)
+
+        for dataset_index in range(1, n_datasets + 1):
+            np.savetxt(
+                object_dir / f"n_{dataset_index}.csv",
+                nuclear_data,
+                fmt="%.10g",
+                delimiter=" ",
+            )
+
+
+def generate_real_space_data(
+    output_dir: Path = REAL_SPACE_DIR,
+    radius: float = 5.0,
+    spacing: float = 0.3554,
+    points_per_axis: int = 29,
+    magnetization: tuple[float, float, float] = (0.0, 0.0, 1.7),
+    nuclear_sld: float = 1.0,
+    n_datasets: int = 6,
+    clean: bool = True,
+) -> Path:
+    """Generate the complete RealSpaceData folder for example 1."""
+
+    output_dir = Path(output_dir)
+
+    if clean and output_dir.exists():
+        shutil.rmtree(output_dir)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    local_positions = sample_spherical_grid(radius, spacing, points_per_axis)
+
+    write_struct_data(output_dir, DEFAULT_OBJECT_CENTERS)
+    write_magnetic_data(output_dir, local_positions, magnetization, len(DEFAULT_OBJECT_CENTERS), n_datasets)
+    write_nuclear_data(output_dir, local_positions, nuclear_sld, len(DEFAULT_OBJECT_CENTERS), n_datasets)
+
+    return output_dir
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments for manual data generation."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, default=REAL_SPACE_DIR)
+    parser.add_argument("--radius", type=float, default=5.0)
+    parser.add_argument("--spacing", type=float, default=0.3554)
+    parser.add_argument("--points-per-axis", type=int, default=29)
+    parser.add_argument("--mx", type=float, default=0.0)
+    parser.add_argument("--my", type=float, default=0.0)
+    parser.add_argument("--mz", type=float, default=1.7)
+    parser.add_argument("--nuclear-sld", type=float, default=1.0)
+    parser.add_argument("--n-datasets", type=int, default=6)
+    parser.add_argument("--no-clean", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Generate the example data set from command line parameters."""
+
+    args = parse_args()
+    output_dir = generate_real_space_data(
+        output_dir=args.output_dir,
+        radius=args.radius,
+        spacing=args.spacing,
+        points_per_axis=args.points_per_axis,
+        magnetization=(args.mx, args.my, args.mz),
+        nuclear_sld=args.nuclear_sld,
+        n_datasets=args.n_datasets,
+        clean=not args.no_clean,
+    )
+    print(f"Generated RealSpaceData in: {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/example1/NuMagSANSrun.py
+++ b/examples/example1/NuMagSANSrun.py
@@ -1,6 +1,13 @@
 from NuMagSANS import NuMagSANS
 from pathlib import Path
+from GenerateRealSpaceData import generate_real_space_data
+
+
 BASE_DIR = Path(__file__).resolve().parent
+
+# Generate the example input data locally so the repository does not need to
+# carry the materialized RealSpaceData files.
+generate_real_space_data(BASE_DIR / "RealSpaceData")
 
 # NuMagSANS object
 sim = NuMagSANS()

--- a/examples/example2/NuMagSANSrun.py
+++ b/examples/example2/NuMagSANSrun.py
@@ -93,6 +93,7 @@ def run_single_case(sim: NuMagSANS, iteration: int, rng: np.random.Generator) ->
         RotDataLoop=1,
         RotDataLoop_From=1,
         RotDataLoop_To=N_ROTDATA,
+        RotData_User_Selection=list(range(1, N_ROTDATA + 1)),
         FastLoad=1,
         MagDataPath=str(BASE_DIR / "RealSpaceData" / "MagData"),
         StructDataFilename=str(BASE_DIR / "RealSpaceData" / "StructData.csv"),

--- a/examples/example2/NuMagSANSrun.py
+++ b/examples/example2/NuMagSANSrun.py
@@ -1,11 +1,13 @@
 from pathlib import Path
 import shutil
+from dataclasses import replace
 
 import numpy as np
 
 from NuMagSANS import NuMagSANS
 from UniformSphere import (
     random_two_sphere_case,
+    random_zyz_angles,
     scaled_spin_flip_1d,
     system_scattering_volume_m3,
     write_uniform_sphere_case,
@@ -23,6 +25,7 @@ N_Q = 160
 N_THETA = 361
 Q_MAX = 1.2
 POLARIZATION = (0.0, 0.0, 1.0)
+N_ROTDATA = 4
 
 
 def read_spin_flip_1d(filename: Path) -> tuple[np.ndarray, np.ndarray]:
@@ -48,12 +51,36 @@ def format_vector(vector: tuple[float, float, float]) -> str:
     return "(" + ", ".join(f"{value: .3f}" for value in vector) + ")"
 
 
+def write_rotdata_loop_cases(rotation_cases: list[list], real_space_dir: Path) -> None:
+    """Write RotData_#.csv files for an inner NuMagSANS rotation-data loop."""
+
+    rotdata_dir = real_space_dir / "RotData"
+    rotdata_dir.mkdir(parents=True, exist_ok=True)
+
+    for index, spheres in enumerate(rotation_cases, start=1):
+        angles = np.asarray([sphere.angles for sphere in spheres], dtype=float)
+        np.savetxt(rotdata_dir / f"RotData_{index}.csv", angles, fmt="%.10e", delimiter=" ")
+
+
+def sample_rotation_cases(spheres: list, rng: np.random.Generator, n_cases: int) -> list[list]:
+    """Return copies of the spheres with independently sampled object rotations."""
+
+    rotation_cases = []
+    for _ in range(n_cases):
+        rotation_cases.append(
+            [replace(sphere, angles=random_zyz_angles(rng)) for sphere in spheres]
+        )
+    return rotation_cases
+
+
 def run_single_case(sim: NuMagSANS, iteration: int, rng: np.random.Generator) -> dict:
     """Generate one random two-sphere case, run NuMagSANS, and compare SpinFlip_1D."""
 
     spheres = random_two_sphere_case(rng)
     scattering_volume = system_scattering_volume_m3(spheres)
     write_uniform_sphere_case(BASE_DIR, spheres, dataset_index=1, clean=True)
+    rotation_cases = sample_rotation_cases(spheres, rng, N_ROTDATA)
+    write_rotdata_loop_cases(rotation_cases, REAL_SPACE_DIR)
 
     if OUTPUT_DIR.exists():
         shutil.rmtree(OUTPUT_DIR)
@@ -63,10 +90,14 @@ def run_single_case(sim: NuMagSANS, iteration: int, rng: np.random.Generator) ->
         MagData_activate=1,
         StructData_activate=1,
         RotData_activate=1,
+        RotDataLoop=1,
+        RotDataLoop_From=1,
+        RotDataLoop_To=N_ROTDATA,
         FastLoad=1,
         MagDataPath=str(BASE_DIR / "RealSpaceData" / "MagData"),
         StructDataFilename=str(BASE_DIR / "RealSpaceData" / "StructData.csv"),
         RotDataFilename=str(BASE_DIR / "RealSpaceData" / "RotData.csv"),
+        RotDataPath=str(BASE_DIR / "RealSpaceData" / "RotData"),
         foldernameSANSData=str(OUTPUT_DIR),
         Fourier_Approach="atomistic",
         Loop_Modus=0,
@@ -84,22 +115,32 @@ def run_single_case(sim: NuMagSANS, iteration: int, rng: np.random.Generator) ->
     finally:
         sim.config_clear(CONFIG)
 
-    q, numagsans_spin_flip = read_spin_flip_1d(OUTPUT_DIR / "SANS_1" / "SANS1D.csv")
-    analytic_spin_flip = scaled_spin_flip_1d(
-        q_values=q,
-        n_theta=N_THETA,
-        spheres=spheres,
-        scattering_volume=scattering_volume,
-        polarization=POLARIZATION,
-    )
-    mse = relative_mse(numagsans_spin_flip, analytic_spin_flip)
+    rotdata_results = []
+    for rotdata_index, rotated_spheres in enumerate(rotation_cases, start=1):
+        q, numagsans_spin_flip = read_spin_flip_1d(
+            OUTPUT_DIR / "SANS_1" / f"RotData_{rotdata_index}" / "SANS1D.csv"
+        )
+        analytic_spin_flip = scaled_spin_flip_1d(
+            q_values=q,
+            n_theta=N_THETA,
+            spheres=rotated_spheres,
+            scattering_volume=scattering_volume,
+            polarization=POLARIZATION,
+        )
+        mse = relative_mse(numagsans_spin_flip, analytic_spin_flip)
+        rotdata_results.append(
+            {
+                "rotdata_index": rotdata_index,
+                "mse": mse,
+                "spheres": rotated_spheres,
+            }
+        )
+        print(f"iteration {iteration}, RotData {rotdata_index}: relative MSE = {mse:.6e}")
 
-    print(f"iteration {iteration}: relative MSE = {mse:.6e}")
     return {
         "iteration": iteration,
-        "mse": mse,
         "scattering_volume": scattering_volume,
-        "spheres": spheres,
+        "rotdata_results": rotdata_results,
     }
 
 
@@ -107,19 +148,32 @@ def print_summary_table(results: list[dict]) -> None:
     """Print MSE values together with the generated two-sphere parameters."""
 
     print("\nSummary:")
-    print(f"{'it':>2} {'MSE':>12} {'particle':>8} {'R':>8} {'a':>8} {'position':>30} {'magnetization':>30}")
+    print(
+        f"{'it':>2} {'rot':>3} {'MSE':>12} {'particle':>8} {'R':>8} {'a':>8} "
+        f"{'position':>30} {'magnetization':>30} {'angles':>30}"
+    )
     for result in results:
-        for particle_index, sphere in enumerate(result["spheres"], start=1):
-            mse = f"{result['mse']:.6e}" if particle_index == 1 else ""
-            iteration = str(result["iteration"]) if particle_index == 1 else ""
-            print(
-                f"{iteration:>2} {mse:>12} {particle_index:>8} "
-                f"{sphere.radius:8.3f} {sphere.spacing:8.3f} "
-                f"{format_vector(sphere.center):>30} "
-                f"{format_vector(sphere.magnetization):>30}"
-            )
+        for rotdata_result in result["rotdata_results"]:
+            for particle_index, sphere in enumerate(rotdata_result["spheres"], start=1):
+                mse = f"{rotdata_result['mse']:.6e}" if particle_index == 1 else ""
+                iteration = str(result["iteration"]) if particle_index == 1 else ""
+                rotdata_index = str(rotdata_result["rotdata_index"]) if particle_index == 1 else ""
+                print(
+                    f"{iteration:>2} {rotdata_index:>3} {mse:>12} {particle_index:>8} "
+                    f"{sphere.radius:8.3f} {sphere.spacing:8.3f} "
+                    f"{format_vector(sphere.center):>30} "
+                    f"{format_vector(sphere.magnetization):>30} "
+                    f"{format_vector(sphere.angles):>30}"
+                )
 
-    mse_values = np.asarray([result["mse"] for result in results], dtype=float)
+    mse_values = np.asarray(
+        [
+            rotdata_result["mse"]
+            for result in results
+            for rotdata_result in result["rotdata_results"]
+        ],
+        dtype=float,
+    )
     print(f"\nmean MSE: {np.mean(mse_values):.6e}")
 
 

--- a/src/NuMagSANS.cu
+++ b/src/NuMagSANS.cu
@@ -74,8 +74,7 @@ int main(int argc, char* argv[]){
 	if(InputData.RotData_activate_flag){
 		if(InputData.RotDataLoop_flag){
 			Check_RotData_Flag = RotDataLoop_Observer(InputData.RotDataPath,
-													  InputData.RotDataLoop_From,
-													  InputData.RotDataLoop_To,
+													  InputData.RotDataLoop_IndexArray,
 													  &RotDataProp);
 		}else{
 			Check_RotData_Flag = RotData_Observer(InputData.RotDataFilename, &RotDataProp);

--- a/src/NuMagSANS.cu
+++ b/src/NuMagSANS.cu
@@ -21,7 +21,6 @@ int main(int argc, char* argv[]){
 	InitializeLogSystem(InputFileName);
 
 	// Input File Interpreter ####################################################################
-	//string InputFileName = argv[1];
 	InputFileData InputData;
     bool Check_InputFile_Flag =	ReadCSV__Input_File_Interpreter(InputFileName, &InputData);
 	if(Check_InputFile_Flag != true){
@@ -65,6 +64,7 @@ int main(int argc, char* argv[]){
 			LogSystem::write(" ->-> Error in StructData!");
 			LogSystem::write("");
 			LogSystem::write("");
+			return 0;
 		}
 	}
 
@@ -72,11 +72,29 @@ int main(int argc, char* argv[]){
 	RotDataProperties RotDataProp;
 	bool Check_RotData_Flag;
 	if(InputData.RotData_activate_flag){
-		Check_RotData_Flag = RotData_Observer(InputData.RotDataFilename, &RotDataProp);
+		if(InputData.RotDataLoop_flag){
+			Check_RotData_Flag = RotDataLoop_Observer(InputData.RotDataPath,
+													  InputData.RotDataLoop_From,
+													  InputData.RotDataLoop_To,
+													  &RotDataProp);
+		}else{
+			Check_RotData_Flag = RotData_Observer(InputData.RotDataFilename, &RotDataProp);
+		}
 		if(Check_RotData_Flag != true){
 			LogSystem::write(" ->-> Error in RotData!");
 			LogSystem::write("");
 			LogSystem::write("");
+			return 0;
+		}
+	}
+
+	if(InputData.StructData_activate_flag && InputData.RotData_activate_flag){
+		if(StructDataProp.Number_Of_Elements != RotDataProp.Number_Of_Elements){
+			LogSystem::write(" ->-> Error: StructData and RotData contain different numbers of entries!");
+			LogSystem::write("StructData entries: " + std::to_string(StructDataProp.Number_Of_Elements));
+			LogSystem::write("RotData entries: " + std::to_string(RotDataProp.Number_Of_Elements));
+			LogSystem::write("");
+			return 0;
 		}
 	}
 
@@ -86,15 +104,7 @@ int main(int argc, char* argv[]){
 
 
 
-	// Create Output Folder #####################################################################
-	//mkdir((InputData.SANSDataFoldername + "/").c_str(), 0777);
-	//LogSystem::initLog(InputData.SANSDataFoldername + "/NuMagSANSlog.txt");
-	//LogSystem::write("Hello World!");
-
-
 	// Start calculation based on loop modus or user selection ###################################
-	//mkdir((InputData.SANSDataFoldername + "/").c_str(), 0777);	
-
 	int Data_File_Index;
 	if(InputData.Loop_Modus){
 		LogSystem::write("loop modus active...");
@@ -112,7 +122,6 @@ int main(int argc, char* argv[]){
 		}
 	}
 	
-
 	LogSystem::close();
 
 	return 0;

--- a/src/NuMagSANSInputTemplate.conf
+++ b/src/NuMagSANSInputTemplate.conf
@@ -15,6 +15,7 @@ NucDataPath = RealSpaceData/NucData;               // foldername where the nucle
 MagDataPath = RealSpaceData/MagData;		      	 // foldername where the magnetization data is stored
 StructDataFilename = RealSpaceData/StructData.csv; // foldername where the structure data is stored
 RotDataFilename = RealSpaceData/RotData.csv;	// foldername where the rotation data is stored
+RotDataPath = RealSpaceData/RotData;    // foldername for RotData_1.csv, RotData_2.csv, ... in RotDataLoop mode
 foldernameSANSData = NuMagSANS_Output;    			 // foldername where the SANS data is to be stored
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -42,6 +43,10 @@ Fourier_Approach = atomistic;	   // (atomistic, micromagnetic)
 Loop_Modus = 0;		// select loop modus with 1, deselect loop modus with 0 (boolean selector)
 Loop_From = 1;		// start index of the parameter loop
 Loop_To = 20; 		// end index of the parameter loop
+
+RotDataLoop = 0;        // select inner rotation data loop with 1, deselect with 0
+RotDataLoop_From = 1;   // start index for RotData/RotData_#.csv files
+RotDataLoop_To = 1;     // end index for RotData/RotData_#.csv files
 
 User_Selection = {1, 2, 3}; // selection of file indices by user (ignored if loop modus is active)
 

--- a/src/NuMagSANSInputTemplate.conf
+++ b/src/NuMagSANSInputTemplate.conf
@@ -47,6 +47,7 @@ Loop_To = 20; 		// end index of the parameter loop
 RotDataLoop = 0;        // select inner rotation data loop with 1, deselect with 0
 RotDataLoop_From = 1;   // start index for RotData/RotData_#.csv files
 RotDataLoop_To = 1;     // end index for RotData/RotData_#.csv files
+// RotData_User_Selection = {1, 3, 4}; // optional explicit selection of RotData_#.csv files; overrides RotDataLoop_From/To if set
 
 User_Selection = {1, 2, 3}; // selection of file indices by user (ignored if loop modus is active)
 

--- a/src/NuMagSANSlib.h
+++ b/src/NuMagSANSlib.h
@@ -85,14 +85,16 @@ void NuMagSANS_Calculator(InputFileData* InputData, \
 
 	if(InputData->RotData_activate_flag && InputData->RotDataLoop_flag){
 
-		for(int RotData_File_Index = InputData->RotDataLoop_From;
-			RotData_File_Index <= InputData->RotDataLoop_To;
-			RotData_File_Index++){
+		for(int RotDataLoop_Counter = 0;
+			RotDataLoop_Counter < InputData->RotDataLoop_IndexArray.size();
+			RotDataLoop_Counter++){
+
+			int RotData_File_Index = InputData->RotDataLoop_IndexArray[RotDataLoop_Counter];
 
 			LogSystem::write("inner RotData loop active: RotData index "
 			                 + std::to_string(RotData_File_Index));
 
-			if(RotData_File_Index != InputData->RotDataLoop_From){
+			if(RotDataLoop_Counter != 0){
 				ResetSANSOutputData(InputData, &Data);
 			}
 

--- a/src/NuMagSANSlib.h
+++ b/src/NuMagSANSlib.h
@@ -1,5 +1,5 @@
 // File         : NuMagSANSlib.h
-// Author       : Dr. Michael Philipp ADAMS 
+// Author       : Dr. Michael Philipp ADAMS
 // Company      : University of Luxembourg
 // Department   : Department of Physics and Materials Sciences
 // Group        : NanoMagnetism Group
@@ -71,32 +71,60 @@ void NuMagSANS_Calculator(InputFileData* InputData, \
 	GPUMemoryInfo MemoryBeforeRun = GetGPUMemoryInfo();
  	LogCurrentGPUMemoryDifference(MemoryBeforeRun);
 
-	// start time measurement 
+	// start time measurement
 	TimeMeasure TotalTime = StartTimeMeasure();
 
-    NuMagSANSData Data;
-
-	// initialize data  
-	InitializeData(InputData, 
+	// initialize data
+	NuMagSANSData Data;
+	InitializeData(InputData,
 		           NucDataProp, MagDataProp, StructDataProp, RotDataProp,
 				   &Data, Data_File_Index);
 
-	// check memory  
+	// check memory
 	LogCurrentGPUMemoryDifference(MemoryBeforeRun);
-		
-	// run gpu kernel  
-	SelectKernelRun(InputData, &Data);
 
-	// run gpu post-processing kernels  
-	KernelPostprocessRun(InputData, &Data);
+	if(InputData->RotData_activate_flag && InputData->RotDataLoop_flag){
 
-	// export data  
-	ExportData(InputData, &Data, Data_File_Index);
+		for(int RotData_File_Index = InputData->RotDataLoop_From;
+			RotData_File_Index <= InputData->RotDataLoop_To;
+			RotData_File_Index++){
 
-	// free memory  
+			LogSystem::write("inner RotData loop active: RotData index "
+			                 + std::to_string(RotData_File_Index));
+
+			if(RotData_File_Index != InputData->RotDataLoop_From){
+				ResetSANSOutputData(InputData, &Data);
+			}
+
+			SetActiveRotDataFile(RotDataProp, RotData_File_Index);
+			new_read_RotationData(&Data.RotData, &Data.RotData_gpu, RotDataProp, InputData);
+
+			// run gpu kernel
+			SelectKernelRun(InputData, &Data);
+
+			// run gpu post-processing kernels
+			KernelPostprocessRun(InputData, &Data);
+
+			// export data
+			ExportData(InputData, &Data, Data_File_Index, RotData_File_Index);
+		}
+
+	}else{
+
+		// run gpu kernel
+		SelectKernelRun(InputData, &Data);
+
+		// run gpu post-processing kernels
+		KernelPostprocessRun(InputData, &Data);
+
+		// export data
+		ExportData(InputData, &Data, Data_File_Index);
+	}
+
+	// free memory
 	FreeData(InputData, &Data);
-	
-	// print result of time measurement 
+
+	// print result of time measurement
     LogElapsedTime(TotalTime);
 
 	LogCurrentGPUMemoryDifference(MemoryBeforeRun);

--- a/src/NuMagSANSlib.h
+++ b/src/NuMagSANSlib.h
@@ -30,6 +30,7 @@
 #include "NuMagSANSlib_LogFile.h"
 #include "NuMagSANSlib_MemoryInfo.h"
 #include "NuMagSANSlib_TimeMeasure.h"
+#include "NuMagSANSlib_CUDAError.h"
 #include "NuMagSANSlib_HelperFun.h"
 #include "NuMagSANSlib_StringCompare.h"
 #include "NuMagSANSlib_ReadWrite.h"
@@ -100,6 +101,7 @@ void NuMagSANS_Calculator(InputFileData* InputData, \
 
 			SetActiveRotDataFile(RotDataProp, RotData_File_Index);
 			new_read_RotationData(&Data.RotData, &Data.RotData_gpu, RotDataProp, InputData);
+			CheckCUDALastError("reload rotation data");
 
 			// run gpu kernel
 			SelectKernelRun(InputData, &Data);
@@ -109,6 +111,7 @@ void NuMagSANS_Calculator(InputFileData* InputData, \
 
 			// export data
 			ExportData(InputData, &Data, Data_File_Index, RotData_File_Index);
+			CheckCUDALastError("export scattering data");
 		}
 
 	}else{
@@ -121,10 +124,12 @@ void NuMagSANS_Calculator(InputFileData* InputData, \
 
 		// export data
 		ExportData(InputData, &Data, Data_File_Index);
+		CheckCUDALastError("export scattering data");
 	}
 
 	// free memory
 	FreeData(InputData, &Data);
+	CheckCUDALastError("free data");
 
 	// print result of time measurement
     LogElapsedTime(TotalTime);

--- a/src/NuMagSANSlib_CUDAError.h
+++ b/src/NuMagSANSlib_CUDAError.h
@@ -1,0 +1,35 @@
+#pragma once
+
+inline bool CheckCUDA(cudaError_t err,
+					  const std::string& context){
+	if(err != cudaSuccess){
+		LogSystem::write("CUDA error in " + context + ": " + cudaGetErrorString(err));
+		return false;
+	}
+
+	return true;
+}
+
+inline bool CheckCUDALastError(const std::string& context){
+	bool success = true;
+
+	success = CheckCUDA(cudaGetLastError(),
+						context) && success;
+
+	success = CheckCUDA(cudaDeviceSynchronize(),
+						context + " synchronization") && success;
+
+	return success;
+}
+
+inline bool CheckCUDAKernelRun(const std::string& kernel_name){
+	bool success = true;
+
+	success = CheckCUDA(cudaGetLastError(),
+						"kernel launch " + kernel_name) && success;
+
+	success = CheckCUDA(cudaDeviceSynchronize(),
+						"kernel execution " + kernel_name) && success;
+
+	return success;
+}

--- a/src/NuMagSANSlib_ExportData.h
+++ b/src/NuMagSANSlib_ExportData.h
@@ -4,7 +4,8 @@ inline void ExportDataMulti(InputFileData* InputData,
 							ScalingFactors* ScalFactors,
 							ScatteringData* SANSData, ScatteringData* SANSData_gpu,
 							SpectralData* SpecData, SpectralData* SpecData_gpu,
-							int Data_File_Index){
+							int Data_File_Index,
+							int RotData_File_Index = 0){
 
 	// copy scattering data from GPU to RAM ###################################################
 	copyGPU2RAM_ScatteringData(SANSData, SANSData_gpu);
@@ -14,7 +15,7 @@ inline void ExportDataMulti(InputFileData* InputData,
 	scale_ScatteringData(ScalFactors, SANSData, InputData);
 
 	// write scattering data to csv files #####################################################
-	write2CSVtable_ScatteringData(InputData, SANSData, Data_File_Index);
+	write2CSVtable_ScatteringData(InputData, SANSData, Data_File_Index, RotData_File_Index);
 
 	if(InputData->AngularSpec_activate_flag){
 		// copy spectral data from GPU to RAM #################################################
@@ -24,19 +25,21 @@ inline void ExportDataMulti(InputFileData* InputData,
 		scale_SpectralData(ScalFactors, SpecData, InputData);
 	
 		// write spectral data to csv files ###################################################
-		write2CSV_SpectralData(InputData, SpecData, Data_File_Index);
+		write2CSV_SpectralData(InputData, SpecData, Data_File_Index, RotData_File_Index);
 	}
 }
 
 
 inline void ExportData(InputFileData* InputData, 
 	                   NuMagSANSData* Data, 
-					   int Data_File_Index){
+					   int Data_File_Index,
+					   int RotData_File_Index = 0){
 
 	ExportDataMulti(InputData,
 					&Data->ScalFactors,
 					&Data->SANSData, &Data->SANSData_gpu,
 					&Data->SpecData, &Data->SpecData_gpu,
-					Data_File_Index);
+					Data_File_Index,
+					RotData_File_Index);
 
 }

--- a/src/NuMagSANSlib_InitializeData.h
+++ b/src/NuMagSANSlib_InitializeData.h
@@ -14,37 +14,23 @@ inline void InitializeDataMulti(InputFileData* InputData,
 									ScalingFactors* ScalFactors,
 									int Data_File_Index){
 
-	cudaError_t err;
-
 	// initialize nuclear data ################################################################
 	if(InputData->NucData_activate_flag){
 		init_NuclearData(NucData, NucData_gpu, NucDataProp, InputData, Data_File_Index);
-		cudaDeviceSynchronize();
-		err = cudaGetLastError();
-		if (err != cudaSuccess) {
-			LogSystem::write(std::string("kernel launch failed: ") + cudaGetErrorString(err));
-		}
+		CheckCUDALastError("initialize nuclear data");
 	}
 	
 	// initialize magnetization data ##########################################################
 	if(InputData->MagData_activate_flag){
 		init_MagnetizationData(MagData, MagData_gpu, MagDataProp, InputData, Data_File_Index);
-		cudaDeviceSynchronize();
-		err = cudaGetLastError();
-		if (err != cudaSuccess) {
-			LogSystem::write(std::string("kernel launch failed: ") + cudaGetErrorString(err));
-		}
+		CheckCUDALastError("initialize magnetization data");
 		//disp_MagnetizationData(MagData);
 	}
 
 	// initialize structure data ##############################################################
 	if(InputData->StructData_activate_flag){
 		init_StructureData(StructData, StructData_gpu, StructDataProp, InputData);
-		cudaDeviceSynchronize();
-		err = cudaGetLastError();
-		if (err != cudaSuccess) {
-			LogSystem::write(std::string("kernel launch failed: ") + cudaGetErrorString(err));
-		}
+		CheckCUDALastError("initialize structure data");
 		//disp_StructureData(StructData);
 	}
 
@@ -55,28 +41,16 @@ inline void InitializeDataMulti(InputFileData* InputData,
 		}else{
 			init_RotationData(RotData, RotData_gpu, RotDataProp, InputData);
 		}
-		cudaDeviceSynchronize();
-		err = cudaGetLastError();
-		if (err != cudaSuccess) {
-			LogSystem::write(std::string("kernel launch failed: ") + cudaGetErrorString(err));
-		}
+		CheckCUDALastError("initialize rotation data");
 	}
 
 	// initialize scattering data #############################################################
 	init_ScatteringData(InputData, SANSData, SANSData_gpu);
-	cudaDeviceSynchronize();
-	err = cudaGetLastError();
-	if (err != cudaSuccess) {
-		LogSystem::write(std::string("kernel launch failed: ") + cudaGetErrorString(err));
-	}
+	CheckCUDALastError("initialize scattering data");
 
 	// initialize spectral data ###############################################################
 	init_SpectralData(InputData, SANSData, SpecData, SpecData_gpu);
-	cudaDeviceSynchronize();
-	err = cudaGetLastError();
-	if (err != cudaSuccess) {
-		LogSystem::write(std::string("kernel launch failed: ") + cudaGetErrorString(err));
-	}
+	CheckCUDALastError("initialize spectral data");
 
 	// initialize scaling factors
 	init_ScalingFactors(ScalFactors, InputData, MagData, NucData, SANSData);
@@ -121,9 +95,5 @@ inline void ResetSANSOutputData(InputFileData* InputData,
 
 	init_ScalingFactors(&Data->ScalFactors, InputData, &Data->MagData, &Data->NucData, &Data->SANSData);
 
-	cudaDeviceSynchronize();
-	cudaError_t err = cudaGetLastError();
-	if (err != cudaSuccess) {
-		LogSystem::write(std::string("CUDA operation failed during SANS output reset: ") + cudaGetErrorString(err));
-	}
+	CheckCUDALastError("reset SANS output data");
 }

--- a/src/NuMagSANSlib_InitializeData.h
+++ b/src/NuMagSANSlib_InitializeData.h
@@ -50,7 +50,11 @@ inline void InitializeDataMulti(InputFileData* InputData,
 
 	// initialize rotation data ###############################################################
 	if(InputData->RotData_activate_flag){
-		init_RotationData(RotData, RotData_gpu, RotDataProp, InputData);
+		if(InputData->RotDataLoop_flag){
+			init_RotationDataMemory(RotData, RotData_gpu, RotDataProp, InputData);
+		}else{
+			init_RotationData(RotData, RotData_gpu, RotDataProp, InputData);
+		}
 		cudaDeviceSynchronize();
 		err = cudaGetLastError();
 		if (err != cudaSuccess) {
@@ -116,4 +120,10 @@ inline void ResetSANSOutputData(InputFileData* InputData,
 	init_SpectralData(InputData, &Data->SANSData, &Data->SpecData, &Data->SpecData_gpu);
 
 	init_ScalingFactors(&Data->ScalFactors, InputData, &Data->MagData, &Data->NucData, &Data->SANSData);
+
+	cudaDeviceSynchronize();
+	cudaError_t err = cudaGetLastError();
+	if (err != cudaSuccess) {
+		LogSystem::write(std::string("CUDA operation failed during SANS output reset: ") + cudaGetErrorString(err));
+	}
 }

--- a/src/NuMagSANSlib_InitializeData.h
+++ b/src/NuMagSANSlib_InitializeData.h
@@ -105,3 +105,15 @@ inline void InitializeData(InputFileData* InputData,
 
 
 	}
+
+inline void ResetSANSOutputData(InputFileData* InputData,
+								NuMagSANSData* Data){
+
+	free_ScatteringData(&Data->SANSData, &Data->SANSData_gpu);
+	free_SpectralData(&Data->SpecData, &Data->SpecData_gpu);
+
+	init_ScatteringData(InputData, &Data->SANSData, &Data->SANSData_gpu);
+	init_SpectralData(InputData, &Data->SANSData, &Data->SpecData, &Data->SpecData_gpu);
+
+	init_ScalingFactors(&Data->ScalFactors, InputData, &Data->MagData, &Data->NucData, &Data->SANSData);
+}

--- a/src/NuMagSANSlib_InputFileInterpreter.h
+++ b/src/NuMagSANSlib_InputFileInterpreter.h
@@ -126,6 +126,12 @@ struct InputFileData{
 
 	/// Final index for rotation data loop mode
 	int RotDataLoop_To = 1;
+
+	/// User-defined rotation-data selection string
+	string RotData_User_Selection;
+
+	/// Parsed rotation-data index list
+	std::vector<int> RotDataLoop_IndexArray;
 	
     /// User-defined dataset selection string
 	string User_Selection;
@@ -395,7 +401,7 @@ static std::vector<int> parse_int_list(const std::string& s)
     std::string trimmed = trim(s);
 
     if (trimmed.front() != '{' || trimmed.back() != '}')
-        throw std::runtime_error("Invalid User_Selection format");
+        throw std::runtime_error("Invalid integer list format");
 
     std::string content = trimmed.substr(1, trimmed.size() - 2);
 
@@ -606,6 +612,7 @@ bool ReadCSV__Input_File_Interpreter(string filename, InputFileData*InputData){
 		{"RotDataPath", &InputData->RotDataPath, false},
 		{"foldernameSANSData", &InputData->SANSDataFoldername, true},
 		{"Fourier_Approach", &InputData->Fourier_Approach, true},
+		{"RotData_User_Selection", &InputData->RotData_User_Selection, false},
 		{"User_Selection", &InputData->User_Selection, true}
 
 	};
@@ -697,6 +704,29 @@ bool ReadCSV__Input_File_Interpreter(string filename, InputFileData*InputData){
                 std::to_string(InputData->User_Selection_IndexArray[k]));
         }
     }
+
+	for (auto& opt : string_options)
+    if (opt.key == "RotData_User_Selection" && opt.found)
+    {
+        InputData->RotDataLoop_IndexArray =
+            parse_int_list(InputData->RotData_User_Selection);
+
+        LogSystem::write("Check RotDataUserSelection entries that are transferred to integer array:");
+
+        for (size_t k = 0; k < InputData->RotDataLoop_IndexArray.size(); ++k)
+        {
+            LogSystem::write(
+                " RotDataUserSelection: " +
+                std::to_string(k) + " : " +
+                std::to_string(InputData->RotDataLoop_IndexArray[k]));
+        }
+    }
+
+	if(InputData->RotDataLoop_flag && InputData->RotDataLoop_IndexArray.empty()){
+		for(int k = InputData->RotDataLoop_From; k <= InputData->RotDataLoop_To; k++){
+			InputData->RotDataLoop_IndexArray.push_back(k);
+		}
+	}
 
 
 

--- a/src/NuMagSANSlib_InputFileInterpreter.h
+++ b/src/NuMagSANSlib_InputFileInterpreter.h
@@ -97,6 +97,9 @@ struct InputFileData{
 	/// CSV file containing rotational information
 	string RotDataFilename;
 
+	/// Directory containing RotData_1.csv, RotData_2.csv, ... files
+	string RotDataPath = "";
+
 	/// Skip repeated MagData dimension checks for faster data import
 	bool FastLoad_flag = false;
 
@@ -109,11 +112,20 @@ struct InputFileData{
     /// Activate loop mode over dataset indices
 	bool Loop_Modus;
 
+	/// Activate inner loop mode over rotation data files
+	bool RotDataLoop_flag = false;
+
     /// Starting index for loop mode
 	int Loop_From;
 
     /// Final index for loop mode
 	int Loop_To;
+
+	/// Starting index for rotation data loop mode
+	int RotDataLoop_From = 1;
+
+	/// Final index for rotation data loop mode
+	int RotDataLoop_To = 1;
 	
     /// User-defined dataset selection string
 	string User_Selection;
@@ -541,6 +553,7 @@ bool ReadCSV__Input_File_Interpreter(string filename, InputFileData*InputData){
 		{"MagData_activate", &InputData->MagData_activate_flag, true},
 		{"StructData_activate", &InputData->StructData_activate_flag, true},
 		{"RotData_activate", &InputData->RotData_activate_flag, true},
+		{"RotDataLoop", &InputData->RotDataLoop_flag, false},
 		{"FastLoad", &InputData->FastLoad_flag, false},
 		{"Exclude_Zero_Moments", &InputData->ExcludeZeroMoments_flag, true},
 		{"Angular_Spec", &InputData->AngularSpec_activate_flag, true},
@@ -553,6 +566,8 @@ bool ReadCSV__Input_File_Interpreter(string filename, InputFileData*InputData){
 
 		{"Loop_From", &InputData->Loop_From, true},
 		{"Loop_To", &InputData->Loop_To, true},
+		{"RotDataLoop_From", &InputData->RotDataLoop_From, false},
+		{"RotDataLoop_To", &InputData->RotDataLoop_To, false},
 		{"Number_Of_q_Points", &InputData->N_q, true},
 		{"Number_Of_theta_Points", &InputData->N_theta, true},
 		{"Number_Of_r_Points", &InputData->N_r, true},
@@ -588,6 +603,7 @@ bool ReadCSV__Input_File_Interpreter(string filename, InputFileData*InputData){
 		{"MagDataPath", &InputData->MagDataPath, true},
 		{"StructDataFilename", &InputData->StructDataFilename, true},
 		{"RotDataFilename", &InputData->RotDataFilename, true},
+		{"RotDataPath", &InputData->RotDataPath, false},
 		{"foldernameSANSData", &InputData->SANSDataFoldername, true},
 		{"Fourier_Approach", &InputData->Fourier_Approach, true},
 		{"User_Selection", &InputData->User_Selection, true}

--- a/src/NuMagSANSlib_KernelPostprocess.h
+++ b/src/NuMagSANSlib_KernelPostprocess.h
@@ -5,7 +5,6 @@ inline void KernelPostprocessRunMulti(InputFileData* InputData,
 									  ScatteringData* SANSData_gpu,
 									  SpectralData* SpecData_gpu){
 
-	cudaError_t err;
 	int L = (*SANSData->N_q) * (*SANSData->N_theta);
 
 	bool compute_1D_azimuthal_average = any_active(InputData->OutFlags.SANS1D);
@@ -15,17 +14,13 @@ inline void KernelPostprocessRunMulti(InputFileData* InputData,
 	if(compute_1D_azimuthal_average || compute_1D_corr || compute_1D_pair){
 		LogSystem::write("run: azimuthal averaging");
 		AzimuthalAverage<<<(L+255)/256, 256>>>(*SANSData_gpu);
-		cudaDeviceSynchronize();
-		err = cudaGetLastError();
-		CheckKernelLaunch(err);
+		CheckCUDAKernelRun("AzimuthalAverage");
 	}
 
 	if(compute_1D_corr || compute_1D_pair){
 		LogSystem::write("run: 1D correlation functions");
 		DistributionFunctions<<<(L+255), 256>>>(*SANSData_gpu);
-		cudaDeviceSynchronize();
-		err = cudaGetLastError();
-		CheckKernelLaunch(err);
+		CheckCUDAKernelRun("DistributionFunctions");
 	}
 
 	bool compute_2D_correlation = any_active(InputData->OutFlags.Corr2D);
@@ -33,23 +28,17 @@ inline void KernelPostprocessRunMulti(InputFileData* InputData,
 	if(compute_2D_correlation){
 		LogSystem::write("run: 2D correlation functions");
 		CorrelationFunction_2D<<<(L+255)/256, 256>>>(*SANSData_gpu);
-		cudaDeviceSynchronize();
-		err = cudaGetLastError();
-		CheckKernelLaunch(err);
+		CheckCUDAKernelRun("CorrelationFunction_2D");
 	}
 
 	if(InputData->AngularSpec_activate_flag){
 		LogSystem::write("run: angular spectrum analyzer");
 		ComputeSpectralDecomposition<<<(L+255)/256, 256>>>(*SANSData_gpu, *SpecData_gpu);
-		cudaDeviceSynchronize();
-		err = cudaGetLastError();
-		CheckKernelLaunch(err);
+		CheckCUDAKernelRun("ComputeSpectralDecomposition");
 
 		LogSystem::write("run: angular amplitude spectrum analyzer");
 		ComputeAngularSpectrumAmplitudes<<<(L+255)/256, 256>>>(*SpecData_gpu);
-		cudaDeviceSynchronize();
-		err = cudaGetLastError();
-		CheckKernelLaunch(err);
+		CheckCUDAKernelRun("ComputeAngularSpectrumAmplitudes");
 	}
 }
 

--- a/src/NuMagSANSlib_KernelSelector.h
+++ b/src/NuMagSANSlib_KernelSelector.h
@@ -1,11 +1,5 @@
 #pragma once
 
-inline void CheckKernelLaunch(cudaError_t err){
-	if (err != cudaSuccess) {
-		LogSystem::write(std::string("kernel launch failed: ") + cudaGetErrorString(err));
-	}
-}
-
 inline void SelectKernelRunMulti(InputFileData* InputData,
 								NuclearData* NucData_gpu,
 								MagnetizationData* MagData_gpu,
@@ -14,7 +8,6 @@ inline void SelectKernelRunMulti(InputFileData* InputData,
 								ScatteringData* SANSData,
 								ScatteringData* SANSData_gpu){
 
-	cudaError_t err;
 	int L = (*SANSData->N_q) * (*SANSData->N_theta);
 	LogSystem::write("total number of Fourier space bins: " + std::to_string(L));
 
@@ -22,108 +15,84 @@ inline void SelectKernelRunMulti(InputFileData* InputData,
 	if(InputData->MagData_activate_flag == 1 && InputData->NucData_activate_flag == 0 && InputData->StructData_activate_flag == 0 && InputData->RotData_activate_flag == 0){
 		LogSystem::write("run: Atomistic_MagSANS_Kernel_dilute");
 		Atomistic_MagSANS_Kernel_dilute<<<(L+255)/256, 256>>>(*MagData_gpu, *SANSData_gpu);
-		cudaDeviceSynchronize();
-		err = cudaGetLastError();
-		CheckKernelLaunch(err);
+		CheckCUDAKernelRun("Atomistic_MagSANS_Kernel_dilute");
 	}
 
 	// Pure Nuclear Scattering Calculator without structure data ##############################
 	if(InputData->MagData_activate_flag == 0 && InputData->NucData_activate_flag == 1 && InputData->StructData_activate_flag == 0 && InputData->RotData_activate_flag == 0){
 		LogSystem::write("run: Atomistic_NucSANS_Kernel_dilute");
 		Atomistic_NucSANS_Kernel_dilute<<<(L+255)/256, 256>>>(*NucData_gpu, *SANSData_gpu);
-		cudaDeviceSynchronize();
-		err = cudaGetLastError();
-		CheckKernelLaunch(err);
+		CheckCUDAKernelRun("Atomistic_NucSANS_Kernel_dilute");
 	}
 
 	// Combined Magnetic and Nuclear Scattering Calculator without structure data #############
 	if(InputData->MagData_activate_flag == 1 && InputData->NucData_activate_flag == 1 && InputData->StructData_activate_flag == 0 && InputData->RotData_activate_flag == 0){
 		LogSystem::write("run: Atomistic_NuMagSANS_Kernel_dilute");
 		Atomistic_NuMagSANS_Kernel_dilute<<<(L+255)/256, 256>>>(*NucData_gpu, *MagData_gpu, *SANSData_gpu);
-		cudaDeviceSynchronize();
-		err = cudaGetLastError();
-		CheckKernelLaunch(err);
+		CheckCUDAKernelRun("Atomistic_NuMagSANS_Kernel_dilute");
 	}
 
 	// Pure Magnetic Scattering Calculator with structure data ################################
 	if(InputData->MagData_activate_flag == 1 && InputData->NucData_activate_flag == 0 && InputData->StructData_activate_flag == 1 && InputData->RotData_activate_flag == 0){
 		LogSystem::write("run: Atomistic_MagSANS_Kernel");
 		Atomistic_MagSANS_Kernel<<<(L+255)/256, 256>>>(*MagData_gpu, *StructData_gpu, *SANSData_gpu);
-		cudaDeviceSynchronize();
-		err = cudaGetLastError();
-		CheckKernelLaunch(err);
+		CheckCUDAKernelRun("Atomistic_MagSANS_Kernel");
 	}
 
 	// Pure Nuclear Scattering Calculator with structure data #################################
 	if(InputData->MagData_activate_flag == 0 && InputData->NucData_activate_flag == 1 && InputData->StructData_activate_flag == 1 && InputData->RotData_activate_flag == 0){
 		LogSystem::write("run: Atomistic_NucSANS_Kernel");
 		Atomistic_NucSANS_Kernel<<<(L+255)/256, 256>>>(*NucData_gpu, *StructData_gpu, *SANSData_gpu);
-		cudaDeviceSynchronize();
-		err = cudaGetLastError();
-		CheckKernelLaunch(err);
+		CheckCUDAKernelRun("Atomistic_NucSANS_Kernel");
 	}
 
 	// Combined Magnetic and Nuclear Scattering Calculator with structure data ################
 	if(InputData->MagData_activate_flag == 1 && InputData->NucData_activate_flag == 1 && InputData->StructData_activate_flag == 1 && InputData->RotData_activate_flag == 0){
 		LogSystem::write("run: Atomistic_NuMagSANS_Kernel");
 		Atomistic_NuMagSANS_Kernel<<<(L+255)/256, 256>>>(*NucData_gpu, *MagData_gpu, *StructData_gpu, *SANSData_gpu);
-		cudaDeviceSynchronize();
-		err = cudaGetLastError();
-		CheckKernelLaunch(err);
+		CheckCUDAKernelRun("Atomistic_NuMagSANS_Kernel");
 	}
 
 	// Pure Magnetic Scattering Calculator with rotation data and without structure data ######
 	if(InputData->MagData_activate_flag == 1 && InputData->NucData_activate_flag == 0 && InputData->StructData_activate_flag == 0 && InputData->RotData_activate_flag == 1){
 		LogSystem::write("run: Atomistic_MagSANS_Kernel_RotDilute");
 		Atomistic_MagSANS_Kernel_RotDilute<<<(L+255)/256, 256>>>(*MagData_gpu, *RotData_gpu, *SANSData_gpu);
-		cudaDeviceSynchronize();
-		err = cudaGetLastError();
-		CheckKernelLaunch(err);
+		CheckCUDAKernelRun("Atomistic_MagSANS_Kernel_RotDilute");
 	}
 
 	// Pure Nuclear Scattering Calculator with rotation data and without structure data #######
 	if(InputData->MagData_activate_flag == 0 && InputData->NucData_activate_flag == 1 && InputData->StructData_activate_flag == 0 && InputData->RotData_activate_flag == 1){
 		LogSystem::write("run: Atomistic_NucSANS_Kernel_RotDilute");
 		Atomistic_NucSANS_Kernel_RotDilute<<<(L+255)/256, 256>>>(*NucData_gpu, *RotData_gpu, *SANSData_gpu);
-		cudaDeviceSynchronize();
-		err = cudaGetLastError();
-		CheckKernelLaunch(err);
+		CheckCUDAKernelRun("Atomistic_NucSANS_Kernel_RotDilute");
 	}
 
 	// Combined Magnetic and Nuclear Scattering Calculator with rotation data #################
 	if(InputData->MagData_activate_flag == 1 && InputData->NucData_activate_flag == 1 && InputData->StructData_activate_flag == 0 && InputData->RotData_activate_flag == 1){
 		LogSystem::write("run: Atomistic_NuMagSANS_Kernel_RotDilute");
 		Atomistic_NuMagSANS_Kernel_RotDilute<<<(L+255)/256, 256>>>(*NucData_gpu, *MagData_gpu, *RotData_gpu, *SANSData_gpu);
-		cudaDeviceSynchronize();
-		err = cudaGetLastError();
-		CheckKernelLaunch(err);
+		CheckCUDAKernelRun("Atomistic_NuMagSANS_Kernel_RotDilute");
 	}
 
 	// Pure Magnetic Scattering Calculator with structure and rotation data ###################
 	if(InputData->MagData_activate_flag == 1 && InputData->NucData_activate_flag == 0 && InputData->StructData_activate_flag == 1 && InputData->RotData_activate_flag == 1){
 		LogSystem::write("run: Atomistic_MagSANS_Kernel_StructRot");
 		Atomistic_MagSANS_Kernel_StructRot<<<(L+255)/256, 256>>>(*MagData_gpu, *StructData_gpu, *RotData_gpu, *SANSData_gpu);
-		cudaDeviceSynchronize();
-		err = cudaGetLastError();
-		CheckKernelLaunch(err);
+		CheckCUDAKernelRun("Atomistic_MagSANS_Kernel_StructRot");
 	}
 
 	// Pure Nuclear Scattering Calculator with structure and rotation data ####################
 	if(InputData->MagData_activate_flag == 0 && InputData->NucData_activate_flag == 1 && InputData->StructData_activate_flag == 1 && InputData->RotData_activate_flag == 1){
 		LogSystem::write("run: Atomistic_NucSANS_Kernel_StructRot");
 		Atomistic_NucSANS_Kernel_StructRot<<<(L+255)/256, 256>>>(*NucData_gpu, *StructData_gpu, *RotData_gpu, *SANSData_gpu);
-		cudaDeviceSynchronize();
-		err = cudaGetLastError();
-		CheckKernelLaunch(err);
+		CheckCUDAKernelRun("Atomistic_NucSANS_Kernel_StructRot");
 	}
 
 	// Combined Magnetic and Nuclear Scattering Calculator with structure and rotation data ###
 	if(InputData->MagData_activate_flag == 1 && InputData->NucData_activate_flag == 1 && InputData->StructData_activate_flag == 1 && InputData->RotData_activate_flag == 1){
 		LogSystem::write("run: Atomistic_NuMagSANS_Kernel_StructRot");
 		Atomistic_NuMagSANS_Kernel_StructRot<<<(L+255)/256, 256>>>(*NucData_gpu, *MagData_gpu, *StructData_gpu, *RotData_gpu, *SANSData_gpu);
-		cudaDeviceSynchronize();
-		err = cudaGetLastError();
-		CheckKernelLaunch(err);
+		CheckCUDAKernelRun("Atomistic_NuMagSANS_Kernel_StructRot");
 	}
 }
 

--- a/src/NuMagSANSlib_RotationData.h
+++ b/src/NuMagSANSlib_RotationData.h
@@ -323,7 +323,6 @@ void RotMat_store(unsigned long int idx, float* RotMat, float*RotMat_idx){
     
 }
 
-
 // here the rotation matrix operations section ends
 ///////////////////////////////////////////////////
 
@@ -385,6 +384,17 @@ void init_RotationData(RotationData* RotData, \
 	read_RotationData(RotData, RotDataProp, InputData);
 	allocate_RotationDataGPU(RotData, RotData_gpu);
    
+}
+
+void new_read_RotationData(RotationData* RotData, \
+                            RotationData* RotData_gpu, \
+                            RotDataProperties* RotDataProp, \
+                            InputFileData* InputData){
+
+    DefaultSet_RotationDataRAM(RotData, RotDataProp, InputData);
+    read_RotationData(RotData, RotDataProp, InputData);
+    copy_RotationDataRAM2GPU(RotData, RotData_gpu);
+
 }
 
 void free_RotationData(RotationData *RotData,

--- a/src/NuMagSANSlib_RotationData.h
+++ b/src/NuMagSANSlib_RotationData.h
@@ -386,6 +386,17 @@ void init_RotationData(RotationData* RotData, \
    
 }
 
+void init_RotationDataMemory(RotationData* RotData, \
+                             RotationData* RotData_gpu, \
+                             RotDataProperties* RotDataProp, \
+                             InputFileData* InputData){
+
+	allocate_RotationDataRAM(RotData, RotDataProp, InputData);
+    DefaultSet_RotationDataRAM(RotData, RotDataProp, InputData);
+	allocate_RotationDataGPU(RotData, RotData_gpu);
+
+}
+
 void new_read_RotationData(RotationData* RotData, \
                             RotationData* RotData_gpu, \
                             RotDataProperties* RotDataProp, \

--- a/src/NuMagSANSlib_RotationDataExplorer.h
+++ b/src/NuMagSANSlib_RotationDataExplorer.h
@@ -32,11 +32,12 @@ using namespace std;
 struct RotDataProperties{
 
     string GlobalFilePath;
+    string GlobalFolderPath;
 
     int Number_Of_Elements;
+    int Number_Of_Files;
     
 };
-
 
 // ###############################################################################################################################################
 // helper functions ##############################################################################################################################
@@ -54,6 +55,41 @@ void get_GlobalRotDataPath(std::string Local_RotDataPath,
     RotDataProp->GlobalFilePath = Local_RotDataPath;
 
     LogSystem::write("found Global RotDataPath: " + RotDataProp->GlobalFilePath);
+}
+
+void get_GlobalRotDataFolderPath(std::string Local_RotDataFolderPath,
+                                 RotDataProperties* RotDataProp){
+
+    char tmp[PATH_MAX];
+    getcwd(tmp, PATH_MAX);
+
+    std::string tmp_string = tmp;
+
+    // RotDataProp->GlobalFolderPath = tmp_string + "/" + Local_RotDataFolderPath;
+    RotDataProp->GlobalFolderPath = Local_RotDataFolderPath;
+
+    LogSystem::write("found Global RotDataFolderPath: " + RotDataProp->GlobalFolderPath);
+}
+
+std::string RotDataLoopFilePath(RotDataProperties* RotDataProp,
+                                int RotData_File_Index){
+
+    return RotDataProp->GlobalFolderPath + "/RotData_" + std::to_string(RotData_File_Index) + ".csv";
+}
+
+bool FileExists(std::string filename){
+
+    ifstream fin(filename);
+    bool exists = fin.good();
+    fin.close();
+    return exists;
+}
+
+void SetActiveRotDataFile(RotDataProperties* RotDataProp,
+                          int RotData_File_Index){
+
+    RotDataProp->GlobalFilePath = RotDataLoopFilePath(RotDataProp, RotData_File_Index);
+    LogSystem::write("active RotDataPath: " + RotDataProp->GlobalFilePath);
 }
 
 
@@ -97,6 +133,8 @@ bool RotData_Observer(std::string Local_RotDataPath,
 
     bool CheckFlag = false;
 
+    RotDataProp->Number_Of_Files = 1;
+
     // get global path of the RotationData file
     get_GlobalRotDataPath(Local_RotDataPath, RotDataProp);
 
@@ -116,6 +154,76 @@ bool RotData_Observer(std::string Local_RotDataPath,
     if(RotDataProp->Number_Of_Elements != 0){
         CheckFlag = true;
     }
+
+    return CheckFlag;
+}
+
+bool RotDataLoop_Observer(std::string Local_RotDataFolderPath,
+                          int RotDataLoop_From,
+                          int RotDataLoop_To,
+                          RotDataProperties* RotDataProp){
+
+    LogSystem::write("##########################################################################################");
+    LogSystem::write("## Run - Rotation Folder Explorer ########################################################");
+    LogSystem::write("##########################################################################################");
+    LogSystem::write("");
+
+    bool CheckFlag = true;
+
+    if(RotDataLoop_From > RotDataLoop_To){
+        LogSystem::write("Error: RotDataLoop_From is larger than RotDataLoop_To.");
+        CheckFlag = false;
+    }
+
+    if(Local_RotDataFolderPath == ""){
+        LogSystem::write("Error: RotDataPath is empty while RotDataLoop is active.");
+        CheckFlag = false;
+    }
+
+    get_GlobalRotDataFolderPath(Local_RotDataFolderPath, RotDataProp);
+
+    RotDataProp->Number_Of_Files = RotDataLoop_To - RotDataLoop_From + 1;
+    RotDataProp->Number_Of_Elements = 0;
+
+    for(int k = RotDataLoop_From; k <= RotDataLoop_To; k++){
+        std::string filename = RotDataLoopFilePath(RotDataProp, k);
+
+        if(!FileExists(filename)){
+            LogSystem::write("Error: missing RotData file: " + filename);
+            CheckFlag = false;
+            continue;
+        }
+
+        int Number_Of_Elements_tmp = 0;
+        NumberOfEntriesInRotationFile(&Number_Of_Elements_tmp, filename);
+
+        LogSystem::write("RotData_" + std::to_string(k) + ".csv entries: "
+                         + std::to_string(Number_Of_Elements_tmp));
+
+        if(Number_Of_Elements_tmp == 0){
+            LogSystem::write("Error: RotData file contains zero entries: " + filename);
+            CheckFlag = false;
+        }
+
+        if(RotDataProp->Number_Of_Elements == 0){
+            RotDataProp->Number_Of_Elements = Number_Of_Elements_tmp;
+        }else if(RotDataProp->Number_Of_Elements != Number_Of_Elements_tmp){
+            LogSystem::write("Error: RotData files do not contain the same number of entries.");
+            CheckFlag = false;
+        }
+    }
+
+    SetActiveRotDataFile(RotDataProp, RotDataLoop_From);
+
+    LogSystem::write("Number of RotData files: " + std::to_string(RotDataProp->Number_Of_Files));
+    LogSystem::write("Number of Entries: " + std::to_string(RotDataProp->Number_Of_Elements));
+    LogSystem::write("");
+
+    LogSystem::write("##########################################################################################");
+    LogSystem::write("## Stop - Rotation Folder Explorer #######################################################");
+    LogSystem::write("##########################################################################################");
+    LogSystem::write("");
+    LogSystem::write("");
 
     return CheckFlag;
 }

--- a/src/NuMagSANSlib_RotationDataExplorer.h
+++ b/src/NuMagSANSlib_RotationDataExplorer.h
@@ -159,8 +159,7 @@ bool RotData_Observer(std::string Local_RotDataPath,
 }
 
 bool RotDataLoop_Observer(std::string Local_RotDataFolderPath,
-                          int RotDataLoop_From,
-                          int RotDataLoop_To,
+                          std::vector<int> RotDataLoop_IndexArray,
                           RotDataProperties* RotDataProp){
 
     LogSystem::write("##########################################################################################");
@@ -170,8 +169,8 @@ bool RotDataLoop_Observer(std::string Local_RotDataFolderPath,
 
     bool CheckFlag = true;
 
-    if(RotDataLoop_From > RotDataLoop_To){
-        LogSystem::write("Error: RotDataLoop_From is larger than RotDataLoop_To.");
+    if(RotDataLoop_IndexArray.empty()){
+        LogSystem::write("Error: RotDataLoop has no active RotData indices.");
         CheckFlag = false;
     }
 
@@ -182,11 +181,12 @@ bool RotDataLoop_Observer(std::string Local_RotDataFolderPath,
 
     get_GlobalRotDataFolderPath(Local_RotDataFolderPath, RotDataProp);
 
-    RotDataProp->Number_Of_Files = RotDataLoop_To - RotDataLoop_From + 1;
+    RotDataProp->Number_Of_Files = RotDataLoop_IndexArray.size();
     RotDataProp->Number_Of_Elements = 0;
 
-    for(int k = RotDataLoop_From; k <= RotDataLoop_To; k++){
-        std::string filename = RotDataLoopFilePath(RotDataProp, k);
+    for(int k = 0; k < RotDataLoop_IndexArray.size(); k++){
+        int RotData_File_Index = RotDataLoop_IndexArray[k];
+        std::string filename = RotDataLoopFilePath(RotDataProp, RotData_File_Index);
 
         if(!FileExists(filename)){
             LogSystem::write("Error: missing RotData file: " + filename);
@@ -197,7 +197,7 @@ bool RotDataLoop_Observer(std::string Local_RotDataFolderPath,
         int Number_Of_Elements_tmp = 0;
         NumberOfEntriesInRotationFile(&Number_Of_Elements_tmp, filename);
 
-        LogSystem::write("RotData_" + std::to_string(k) + ".csv entries: "
+        LogSystem::write("RotData_" + std::to_string(RotData_File_Index) + ".csv entries: "
                          + std::to_string(Number_Of_Elements_tmp));
 
         if(Number_Of_Elements_tmp == 0){
@@ -213,7 +213,9 @@ bool RotDataLoop_Observer(std::string Local_RotDataFolderPath,
         }
     }
 
-    SetActiveRotDataFile(RotDataProp, RotDataLoop_From);
+    if(!RotDataLoop_IndexArray.empty()){
+        SetActiveRotDataFile(RotDataProp, RotDataLoop_IndexArray[0]);
+    }
 
     LogSystem::write("Number of RotData files: " + std::to_string(RotDataProp->Number_Of_Files));
     LogSystem::write("Number of Entries: " + std::to_string(RotDataProp->Number_Of_Elements));

--- a/src/NuMagSANSlib_SANSData.h
+++ b/src/NuMagSANSlib_SANSData.h
@@ -1206,7 +1206,8 @@ std::vector<Column> build_Corr2D_columns(
 void write2CSVtable_ScatteringData(
     InputFileData* InputData,
     ScatteringData* SANSData,
-    int MagData_File_Index
+    int MagData_File_Index,
+	int RotData_File_Index = 0
 ){
     LogSystem::write("");
     LogSystem::write("write scattering data to csv-files...");
@@ -1214,6 +1215,10 @@ void write2CSVtable_ScatteringData(
     std::string target_foldername =
         InputData->SANSDataFoldername + "/SANS_" +
         std::to_string(MagData_File_Index) + "/";
+
+	if(RotData_File_Index > 0){
+		target_foldername += "RotData_" + std::to_string(RotData_File_Index) + "/";
+	}
 
     //mkdir(target_foldername.c_str(), 0777);
 	std::filesystem::create_directories(target_foldername);

--- a/src/NuMagSANSlib_SpectralData.h
+++ b/src/NuMagSANSlib_SpectralData.h
@@ -482,7 +482,8 @@ std::vector<SpectralComponent> build_spectral_amplitudes(SpectralData* SpecData)
 void write2CSV_SpectralData(
     InputFileData* InputData,
     SpectralData* SpecData,
-    int MagData_File_Index)
+    int MagData_File_Index,
+    int RotData_File_Index = 0)
 {
     LogSystem::write("");
     LogSystem::write("write spectral decomposition data to csv-files...");
@@ -490,7 +491,13 @@ void write2CSV_SpectralData(
     std::string baseFolder =
         InputData->SANSDataFoldername +
         "/SANS_" + std::to_string(MagData_File_Index) +
-        "/AngularSpectrum/";
+        "/";
+
+    if(RotData_File_Index > 0){
+        baseFolder += "RotData_" + std::to_string(RotData_File_Index) + "/";
+    }
+
+    baseFolder += "AngularSpectrum/";
 
     //mkdir(baseFolder.c_str(), 0777);
     std::filesystem::create_directories(baseFolder);
@@ -633,6 +640,5 @@ void free_SpectralData(SpectralData* S, \
     cudaDeviceSynchronize();
 
 }
-
 
 

--- a/src/NuMagSANSlib_SpectralData.h
+++ b/src/NuMagSANSlib_SpectralData.h
@@ -310,7 +310,7 @@ void allocate_SpectralData_GPU(SpectralData* SpecData, \
     cudaMemset(SpecData_gpu->A_Mag_sanspol_m,        0, len_A);
 
     cudaMalloc(&SpecData_gpu, sizeof(SpectralData));
-    cudaMemcpy(SpecData_gpu, SpecData, sizeof(ScatteringData), cudaMemcpyHostToDevice);
+    cudaMemcpy(SpecData_gpu, SpecData, sizeof(SpectralData), cudaMemcpyHostToDevice);
 
 	cudaDeviceSynchronize();
 	
@@ -640,5 +640,4 @@ void free_SpectralData(SpectralData* S, \
     cudaDeviceSynchronize();
 
 }
-
 


### PR DESCRIPTION
## Summary

This PR adds an inner `RotData` loop to NuMagSANS so that fixed magnetic/nuclear/structure data can be evaluated against multiple rotation-data files without reloading the full real-space dataset.

Main changes:
- Add optional config parameters:
  - `RotDataPath`
  - `RotDataLoop`
  - `RotDataLoop_From`
  - `RotDataLoop_To`
- Support folder-based rotation input:
  - `RealSpaceData/RotData/RotData_1.csv`
  - `RealSpaceData/RotData/RotData_2.csv`
  - ...
- Add rotation-folder checks in `RotationDataExplorer`.
- Reload only `RotationData` inside the inner loop via `new_read_RotationData(...)`.
- Reset SANS/Spectral output data between rotation-loop steps.
- Export looped results into separate folders:
  - `SANS_1/RotData_1/`
  - `SANS_1/RotData_2/`
  - ...
- Extend the Python facade to write the new config keys.
- Update `example2` to generate and validate four random `RotData` cases per test iteration.
- Add a generator for `example1` real-space data so the example can materialize its input dataset from Python.

## Testing

Local:
- `git diff --check`
- Python syntax checks for the modified example/facade files
- Verified that generated `example1` `RealSpaceData` matches the previous checked-in CSV dataset byte-for-byte.

HPC/GPU:
- CUDA build succeeded with CUDA 12.6.77.
- `examples/example1/NuMagSANSrun.py` completed.
- `examples/example2/NuMagSANSrun.py` completed with 5 random cases and 4 RotData loop entries per case.
- Relative MSE values remained small across all RotData loop entries.