### PR TITLE
update loop over structure data

### DIFF
--- a/NuMagSANS/NuMagSANS.py
+++ b/NuMagSANS/NuMagSANS.py
@@ -79,6 +79,7 @@ class NuMagSANS:
         MagDataPath="RealSpaceData/MagData",
         StructDataFilename="RealSpaceData/StructData.csv",
         RotDataFilename="RealSpaceData/RotData.csv",
+        StructDataPath="RealSpaceData/StructData",
         RotDataPath="RealSpaceData/RotData",
         foldernameSANSData="NuMagSANS_Output",
 
@@ -97,6 +98,10 @@ class NuMagSANS:
         Loop_Modus=0,
         Loop_From=1,
         Loop_To=20,
+        StructDataLoop=0,
+        StructDataLoop_From=1,
+        StructDataLoop_To=1,
+        StructData_User_Selection=None,
         RotDataLoop=0,
         RotDataLoop_From=1,
         RotDataLoop_To=1,
@@ -157,6 +162,7 @@ class NuMagSANS:
             W("MagDataPath", MagDataPath)
             W("StructDataFilename", StructDataFilename)
             W("RotDataFilename", RotDataFilename)
+            W("StructDataPath", StructDataPath)
             W("RotDataPath", RotDataPath)
             W("foldernameSANSData", foldernameSANSData)
 
@@ -181,6 +187,11 @@ class NuMagSANS:
             W("Loop_Modus", Loop_Modus)
             W("Loop_From", Loop_From)
             W("Loop_To", Loop_To)
+            W("StructDataLoop", StructDataLoop)
+            W("StructDataLoop_From", StructDataLoop_From)
+            W("StructDataLoop_To", StructDataLoop_To)
+            if StructData_User_Selection is not None:
+                W("StructData_User_Selection", "{" + ", ".join(map(str, StructData_User_Selection)) + "}")
             W("RotDataLoop", RotDataLoop)
             W("RotDataLoop_From", RotDataLoop_From)
             W("RotDataLoop_To", RotDataLoop_To)

--- a/docs/GettingStarted/ParameterOverview.rst
+++ b/docs/GettingStarted/ParameterOverview.rst
@@ -101,6 +101,14 @@ local object data without rewriting the object files.
 ``StructData_activate``
     Default value 0
 
+``StructDataPath``
+    Default path ``RealSpaceData/StructData``
+
+    Folder used by ``StructDataLoop``. In this mode, structure files are
+    expected to follow the naming convention ``StructData_1.csv``,
+    ``StructData_2.csv``, ... inside ``StructDataPath``. Each file contains one
+    object-center translation table.
+
 ``RotDataFilename``
     Default path ``RealSpaceData/RotData.csv``
 
@@ -206,6 +214,35 @@ These parameters control batch simulations or repeated calculations.
     ``Loop_Modus = 1``, the index range from ``Loop_From`` to ``Loop_To`` is
     used.
 
+``StructDataLoop``
+    Description: Enable an inner loop over several structure-data files.
+    Default ``0``
+
+    If ``StructDataLoop = 1``, NuMagSANS loads the selected
+    ``StructData_#.csv`` files from ``StructDataPath`` while keeping the
+    currently selected magnetic and nuclear local object data fixed. If
+    ``RotDataLoop`` is also active, the structure-data loop is the outer loop
+    and the rotation-data loop is the inner loop.
+
+``StructDataLoop_From``
+    Description: First structure-data file index used by the inner StructData
+    loop.
+    Default ``1``
+
+``StructDataLoop_To``
+    Description: Last structure-data file index used by the inner StructData
+    loop.
+    Default ``1``
+
+``StructData_User_Selection``
+    Description: Optional explicit list of selected structure-data file
+    indices.
+
+    If this option is present, it selects the exact ``StructData_#.csv`` files
+    used by the inner StructData loop, for example ``{1, 3, 4}``. If it is not
+    present, the contiguous range from ``StructDataLoop_From`` to
+    ``StructDataLoop_To`` is used.
+
 ``RotDataLoop``
     Description: Enable an inner loop over several rotation-data files.
     Default ``0``
@@ -232,7 +269,9 @@ These parameters control batch simulations or repeated calculations.
     ``RotDataLoop_To`` is used.
 
     For a fixed data-file index and a selected rotation-data index, output is
-    written to a nested folder such as ``SANS_1/RotData_3/``.
+    written to a nested folder such as ``SANS_1/RotData_3/``. If
+    ``StructDataLoop`` is active as well, the output is nested as
+    ``SANS_1/StructData_2/RotData_3/``.
 
 Constant Parameters
 -------------------

--- a/docs/GettingStarted/SimulationScenarios.rst
+++ b/docs/GettingStarted/SimulationScenarios.rst
@@ -57,22 +57,23 @@ later scenarios only describe the additional object folders, data files,
 metadata layers, or loop settings.
 
 Combinatorially, the core real-space input organization already contains
-``18`` basic data-layer scenarios. There are three choices for the physical
+``27`` basic data-layer scenarios. There are three choices for the physical
 local data layer, namely ``MagData``, ``NucData``, or ``MagData + NucData``.
-For each of these choices, ``StructData`` can currently be inactive or active
-as a single ``StructData.csv`` file. In addition, ``RotData`` can be inactive,
-active as a single ``RotData.csv`` file, or active as a folder loop over
-several ``RotData_#.csv`` files.
+For each of these choices, ``StructData`` can be inactive, active as a single
+``StructData.csv`` file, or active as a folder loop over several
+``StructData_#.csv`` files. In addition, ``RotData`` can be inactive, active
+as a single ``RotData.csv`` file, or active as a folder loop over several
+``RotData_#.csv`` files.
 
 .. code-block:: text
 
-   3 local-data choices x 2 StructData choices x 3 RotData choices = 18 scenarios
+   3 local-data choices x 3 StructData choices x 3 RotData choices = 27 scenarios
 
 This count describes the data-layer combinations. The local data-file
 selection adds another execution layer: a calculation can either use selected
 file indices through ``User_Selection`` or sweep consecutive file indices
 through ``Loop_Modus``. If this execution-layer distinction is counted as a
-separate binary choice, the ``18`` data-layer scenarios become ``36`` basic
+separate binary choice, the ``27`` data-layer scenarios become ``54`` basic
 execution scenarios.
 
 The following sections do not document every possible combination separately.
@@ -360,12 +361,12 @@ is added using the same object-folder and file-index convention introduced
 above.
 
 
-Scenario 8: Sweeping several RotData files
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Scenario 8: Sweeping several StructData or RotData files
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For orientation sweeps, ``RotData`` can also be organized as a folder
-containing several rotation datasets. The local object data and optional
-``StructData`` are imported once, while NuMagSANS loops over selected
+For assembly sweeps, ``StructData`` and ``RotData`` can also be organized as
+folders containing several metadata datasets. The local object data are
+imported once, while NuMagSANS loops over selected ``StructData`` and/or
 ``RotData`` files.
 
 .. code-block:: text
@@ -376,17 +377,26 @@ containing several rotation datasets. The local object data and optional
          m_1.csv
        Object_2/
          m_1.csv
-     StructData.csv
+     StructData/
+       StructData_1.csv
+       StructData_2.csv
+       StructData_3.csv
      RotData/
        RotData_1.csv
        RotData_2.csv
        RotData_3.csv
 
-Each ``RotData_#.csv`` file follows the same row convention as the single-file
-``RotData.csv`` case. The active rotation files can be selected explicitly:
+Each ``StructData_#.csv`` file follows the same row convention as the
+single-file ``StructData.csv`` case, and each ``RotData_#.csv`` file follows
+the same row convention as the single-file ``RotData.csv`` case. The active
+files can be selected explicitly:
 
 .. code-block:: conf
 
+   StructData_activate = 1;
+   StructDataLoop = 1;
+   StructDataPath = RealSpaceData/StructData;
+   StructData_User_Selection = {1, 2, 3};
    RotData_activate = 1;
    RotDataLoop = 1;
    RotDataPath = RealSpaceData/RotData;
@@ -396,12 +406,17 @@ or through a consecutive loop range:
 
 .. code-block:: conf
 
+   StructDataLoop = 1;
+   StructDataLoop_From = 1;
+   StructDataLoop_To = 3;
    RotDataLoop = 1;
    RotDataLoop_From = 1;
    RotDataLoop_To = 3;
 
-This mode is intended for repeated calculations with fixed local object data
-and changing object-wise orientations.
+If both loops are active, NuMagSANS evaluates the selected structure-data
+files in the outer loop and the selected rotation-data files in the inner
+loop. The corresponding output is written to nested folders such as
+``SANS_1/StructData_2/RotData_3/``.
 
 
 
@@ -418,8 +433,10 @@ The following consistency rules should be satisfied:
   enumeration starting from ``1``.
 - For a selected data-file index ``k``, each active object folder should
   contain the corresponding ``m_k.csv`` or ``n_k.csv`` file.
-- If ``StructData`` is active, the number of rows in ``StructData.csv`` must
-  match the number of local objects.
+- If ``StructData`` is active without ``StructDataLoop``, the number of rows in
+  ``StructData.csv`` must match the number of local objects.
+- If ``StructDataLoop`` is active, every selected ``StructData_#.csv`` file
+  must contain one row per local object.
 - If ``RotData`` is active without ``RotDataLoop``, the number of rows in
   ``RotData.csv`` must match the number of local objects.
 - If ``RotDataLoop`` is active, every selected ``RotData_#.csv`` file must

--- a/examples/example2/NuMagSANSrun.py
+++ b/examples/example2/NuMagSANSrun.py
@@ -25,6 +25,7 @@ N_Q = 160
 N_THETA = 361
 Q_MAX = 1.2
 POLARIZATION = (0.0, 0.0, 1.0)
+N_STRUCTDATA = 3
 N_ROTDATA = 4
 
 
@@ -62,6 +63,37 @@ def write_rotdata_loop_cases(rotation_cases: list[list], real_space_dir: Path) -
         np.savetxt(rotdata_dir / f"RotData_{index}.csv", angles, fmt="%.10e", delimiter=" ")
 
 
+def write_structdata_loop_cases(structure_cases: list[list], real_space_dir: Path) -> None:
+    """Write StructData_#.csv files for an inner NuMagSANS structure-data loop."""
+
+    structdata_dir = real_space_dir / "StructData"
+    structdata_dir.mkdir(parents=True, exist_ok=True)
+
+    for index, spheres in enumerate(structure_cases, start=1):
+        centers = np.asarray([sphere.center for sphere in spheres], dtype=float)
+        np.savetxt(structdata_dir / f"StructData_{index}.csv", centers, fmt="%.10e", delimiter=" ")
+
+
+def sample_structure_cases(spheres: list, rng: np.random.Generator, n_cases: int) -> list[list]:
+    """Return copies of the spheres with independently sampled object centers."""
+
+    structure_cases = []
+    r1 = spheres[0].radius
+    r2 = spheres[1].radius
+    for _ in range(n_cases):
+        direction = random_unit_vector(rng)
+        distance = (r1 + r2) * rng.uniform(1.25, 1.8)
+        center1 = -0.5 * distance * direction
+        center2 = 0.5 * distance * direction
+        structure_cases.append(
+            [
+                replace(spheres[0], center=tuple(center1)),
+                replace(spheres[1], center=tuple(center2)),
+            ]
+        )
+    return structure_cases
+
+
 def sample_rotation_cases(spheres: list, rng: np.random.Generator, n_cases: int) -> list[list]:
     """Return copies of the spheres with independently sampled object rotations."""
 
@@ -79,6 +111,8 @@ def run_single_case(sim: NuMagSANS, iteration: int, rng: np.random.Generator) ->
     spheres = random_two_sphere_case(rng)
     scattering_volume = system_scattering_volume_m3(spheres)
     write_uniform_sphere_case(BASE_DIR, spheres, dataset_index=1, clean=True)
+    structure_cases = sample_structure_cases(spheres, rng, N_STRUCTDATA)
+    write_structdata_loop_cases(structure_cases, REAL_SPACE_DIR)
     rotation_cases = sample_rotation_cases(spheres, rng, N_ROTDATA)
     write_rotdata_loop_cases(rotation_cases, REAL_SPACE_DIR)
 
@@ -90,6 +124,10 @@ def run_single_case(sim: NuMagSANS, iteration: int, rng: np.random.Generator) ->
         MagData_activate=1,
         StructData_activate=1,
         RotData_activate=1,
+        StructDataLoop=1,
+        StructDataLoop_From=1,
+        StructDataLoop_To=N_STRUCTDATA,
+        StructData_User_Selection=list(range(1, N_STRUCTDATA + 1)),
         RotDataLoop=1,
         RotDataLoop_From=1,
         RotDataLoop_To=N_ROTDATA,
@@ -97,6 +135,7 @@ def run_single_case(sim: NuMagSANS, iteration: int, rng: np.random.Generator) ->
         FastLoad=1,
         MagDataPath=str(BASE_DIR / "RealSpaceData" / "MagData"),
         StructDataFilename=str(BASE_DIR / "RealSpaceData" / "StructData.csv"),
+        StructDataPath=str(BASE_DIR / "RealSpaceData" / "StructData"),
         RotDataFilename=str(BASE_DIR / "RealSpaceData" / "RotData.csv"),
         RotDataPath=str(BASE_DIR / "RealSpaceData" / "RotData"),
         foldernameSANSData=str(OUTPUT_DIR),
@@ -116,32 +155,45 @@ def run_single_case(sim: NuMagSANS, iteration: int, rng: np.random.Generator) ->
     finally:
         sim.config_clear(CONFIG)
 
-    rotdata_results = []
-    for rotdata_index, rotated_spheres in enumerate(rotation_cases, start=1):
-        q, numagsans_spin_flip = read_spin_flip_1d(
-            OUTPUT_DIR / "SANS_1" / f"RotData_{rotdata_index}" / "SANS1D.csv"
-        )
-        analytic_spin_flip = scaled_spin_flip_1d(
-            q_values=q,
-            n_theta=N_THETA,
-            spheres=rotated_spheres,
-            scattering_volume=scattering_volume,
-            polarization=POLARIZATION,
-        )
-        mse = relative_mse(numagsans_spin_flip, analytic_spin_flip)
-        rotdata_results.append(
-            {
-                "rotdata_index": rotdata_index,
-                "mse": mse,
-                "spheres": rotated_spheres,
-            }
-        )
-        print(f"iteration {iteration}, RotData {rotdata_index}: relative MSE = {mse:.6e}")
+    loop_results = []
+    for structdata_index, structured_spheres in enumerate(structure_cases, start=1):
+        for rotdata_index, rotation_spheres in enumerate(rotation_cases, start=1):
+            test_spheres = [
+                replace(structured_sphere, angles=rotation_sphere.angles)
+                for structured_sphere, rotation_sphere in zip(structured_spheres, rotation_spheres)
+            ]
+            q, numagsans_spin_flip = read_spin_flip_1d(
+                OUTPUT_DIR
+                / "SANS_1"
+                / f"StructData_{structdata_index}"
+                / f"RotData_{rotdata_index}"
+                / "SANS1D.csv"
+            )
+            analytic_spin_flip = scaled_spin_flip_1d(
+                q_values=q,
+                n_theta=N_THETA,
+                spheres=test_spheres,
+                scattering_volume=scattering_volume,
+                polarization=POLARIZATION,
+            )
+            mse = relative_mse(numagsans_spin_flip, analytic_spin_flip)
+            loop_results.append(
+                {
+                    "structdata_index": structdata_index,
+                    "rotdata_index": rotdata_index,
+                    "mse": mse,
+                    "spheres": test_spheres,
+                }
+            )
+            print(
+                f"iteration {iteration}, StructData {structdata_index}, "
+                f"RotData {rotdata_index}: relative MSE = {mse:.6e}"
+            )
 
     return {
         "iteration": iteration,
         "scattering_volume": scattering_volume,
-        "rotdata_results": rotdata_results,
+        "loop_results": loop_results,
     }
 
 
@@ -150,17 +202,19 @@ def print_summary_table(results: list[dict]) -> None:
 
     print("\nSummary:")
     print(
-        f"{'it':>2} {'rot':>3} {'MSE':>12} {'particle':>8} {'R':>8} {'a':>8} "
+        f"{'it':>2} {'str':>3} {'rot':>3} {'MSE':>12} {'particle':>8} {'R':>8} {'a':>8} "
         f"{'position':>30} {'magnetization':>30} {'angles':>30}"
     )
     for result in results:
-        for rotdata_result in result["rotdata_results"]:
-            for particle_index, sphere in enumerate(rotdata_result["spheres"], start=1):
-                mse = f"{rotdata_result['mse']:.6e}" if particle_index == 1 else ""
+        for loop_result in result["loop_results"]:
+            for particle_index, sphere in enumerate(loop_result["spheres"], start=1):
+                mse = f"{loop_result['mse']:.6e}" if particle_index == 1 else ""
                 iteration = str(result["iteration"]) if particle_index == 1 else ""
-                rotdata_index = str(rotdata_result["rotdata_index"]) if particle_index == 1 else ""
+                structdata_index = str(loop_result["structdata_index"]) if particle_index == 1 else ""
+                rotdata_index = str(loop_result["rotdata_index"]) if particle_index == 1 else ""
                 print(
-                    f"{iteration:>2} {rotdata_index:>3} {mse:>12} {particle_index:>8} "
+                    f"{iteration:>2} {structdata_index:>3} {rotdata_index:>3} "
+                    f"{mse:>12} {particle_index:>8} "
                     f"{sphere.radius:8.3f} {sphere.spacing:8.3f} "
                     f"{format_vector(sphere.center):>30} "
                     f"{format_vector(sphere.magnetization):>30} "
@@ -169,9 +223,9 @@ def print_summary_table(results: list[dict]) -> None:
 
     mse_values = np.asarray(
         [
-            rotdata_result["mse"]
+            loop_result["mse"]
             for result in results
-            for rotdata_result in result["rotdata_results"]
+            for loop_result in result["loop_results"]
         ],
         dtype=float,
     )

--- a/examples/example2/NuMagSANSrun.py
+++ b/examples/example2/NuMagSANSrun.py
@@ -7,6 +7,7 @@ import numpy as np
 from NuMagSANS import NuMagSANS
 from UniformSphere import (
     random_two_sphere_case,
+    random_unit_vector,
     random_zyz_angles,
     scaled_spin_flip_1d,
     system_scattering_volume_m3,

--- a/src/InputData/NuMagSANSlib_InputFileInterpreter.h
+++ b/src/InputData/NuMagSANSlib_InputFileInterpreter.h
@@ -97,6 +97,9 @@ struct InputFileData{
 	/// CSV file containing rotational information
 	string RotDataFilename;
 
+	/// Directory containing StructData_1.csv, StructData_2.csv, ... files
+	string StructDataPath = "";
+
 	/// Directory containing RotData_1.csv, RotData_2.csv, ... files
 	string RotDataPath = "";
 
@@ -115,6 +118,9 @@ struct InputFileData{
 	/// Activate inner loop mode over rotation data files
 	bool RotDataLoop_flag = false;
 
+	/// Activate inner loop mode over structure data files
+	bool StructDataLoop_flag = false;
+
     /// Starting index for loop mode
 	int Loop_From;
 
@@ -126,6 +132,18 @@ struct InputFileData{
 
 	/// Final index for rotation data loop mode
 	int RotDataLoop_To = 1;
+
+	/// Starting index for structure data loop mode
+	int StructDataLoop_From = 1;
+
+	/// Final index for structure data loop mode
+	int StructDataLoop_To = 1;
+
+	/// User-defined structure-data selection string
+	string StructData_User_Selection;
+
+	/// Parsed structure-data index list
+	std::vector<int> StructDataLoop_IndexArray;
 
 	/// User-defined rotation-data selection string
 	string RotData_User_Selection;
@@ -559,6 +577,7 @@ bool ReadCSV__Input_File_Interpreter(string filename, InputFileData*InputData){
 		{"MagData_activate", &InputData->MagData_activate_flag, true},
 		{"StructData_activate", &InputData->StructData_activate_flag, true},
 		{"RotData_activate", &InputData->RotData_activate_flag, true},
+		{"StructDataLoop", &InputData->StructDataLoop_flag, false},
 		{"RotDataLoop", &InputData->RotDataLoop_flag, false},
 		{"FastLoad", &InputData->FastLoad_flag, false},
 		{"Exclude_Zero_Moments", &InputData->ExcludeZeroMoments_flag, true},
@@ -572,6 +591,8 @@ bool ReadCSV__Input_File_Interpreter(string filename, InputFileData*InputData){
 
 		{"Loop_From", &InputData->Loop_From, true},
 		{"Loop_To", &InputData->Loop_To, true},
+		{"StructDataLoop_From", &InputData->StructDataLoop_From, false},
+		{"StructDataLoop_To", &InputData->StructDataLoop_To, false},
 		{"RotDataLoop_From", &InputData->RotDataLoop_From, false},
 		{"RotDataLoop_To", &InputData->RotDataLoop_To, false},
 		{"Number_Of_q_Points", &InputData->N_q, true},
@@ -609,9 +630,11 @@ bool ReadCSV__Input_File_Interpreter(string filename, InputFileData*InputData){
 		{"MagDataPath", &InputData->MagDataPath, true},
 		{"StructDataFilename", &InputData->StructDataFilename, true},
 		{"RotDataFilename", &InputData->RotDataFilename, true},
+		{"StructDataPath", &InputData->StructDataPath, false},
 		{"RotDataPath", &InputData->RotDataPath, false},
 		{"foldernameSANSData", &InputData->SANSDataFoldername, true},
 		{"Fourier_Approach", &InputData->Fourier_Approach, true},
+		{"StructData_User_Selection", &InputData->StructData_User_Selection, false},
 		{"RotData_User_Selection", &InputData->RotData_User_Selection, false},
 		{"User_Selection", &InputData->User_Selection, true}
 
@@ -704,6 +727,29 @@ bool ReadCSV__Input_File_Interpreter(string filename, InputFileData*InputData){
                 std::to_string(InputData->User_Selection_IndexArray[k]));
         }
     }
+
+	for (auto& opt : string_options)
+    if (opt.key == "StructData_User_Selection" && opt.found)
+    {
+        InputData->StructDataLoop_IndexArray =
+            parse_int_list(InputData->StructData_User_Selection);
+
+        LogSystem::write("Check StructDataUserSelection entries that are transferred to integer array:");
+
+        for (size_t k = 0; k < InputData->StructDataLoop_IndexArray.size(); ++k)
+        {
+            LogSystem::write(
+                " StructDataUserSelection: " +
+                std::to_string(k) + " : " +
+                std::to_string(InputData->StructDataLoop_IndexArray[k]));
+        }
+    }
+
+	if(InputData->StructDataLoop_flag && InputData->StructDataLoop_IndexArray.empty()){
+		for(int k = InputData->StructDataLoop_From; k <= InputData->StructDataLoop_To; k++){
+			InputData->StructDataLoop_IndexArray.push_back(k);
+		}
+	}
 
 	for (auto& opt : string_options)
     if (opt.key == "RotData_User_Selection" && opt.found)

--- a/src/InputData/StructData/NuMagSANSlib_StructureData.h
+++ b/src/InputData/StructData/NuMagSANSlib_StructureData.h
@@ -80,7 +80,7 @@ void allocate_StructureDataGPU(StructureData* StructData, \
 
 	cudaMemcpy(StructData_gpu->K, StructData->K, sizeof(unsigned long int), cudaMemcpyHostToDevice);
 	cudaMemcpy(StructData_gpu->RotMat, StructData->RotMat, 9*sizeof(float), cudaMemcpyHostToDevice);
-		
+
 	LogSystem::write("");
          // copy data from Host to Device
 	LogSystem::write("copy data from RAM to GPU...");
@@ -97,6 +97,28 @@ void allocate_StructureDataGPU(StructureData* StructData, \
 	cudaMalloc(&StructData_gpu, sizeof(StructureData));
 	cudaMemcpy(StructData_gpu, StructData, sizeof(StructureData), cudaMemcpyHostToDevice);
      
+}
+
+void copy_StructureDataRAM2GPU(StructureData* StructData, \
+                               StructureData* StructData_gpu){
+
+     unsigned long int K = *StructData->K;
+
+	cudaMemcpy(StructData_gpu->K, StructData->K, sizeof(unsigned long int), cudaMemcpyHostToDevice);
+	cudaMemcpy(StructData_gpu->RotMat, StructData->RotMat, 9*sizeof(float), cudaMemcpyHostToDevice);
+
+	LogSystem::write("");
+	LogSystem::write("copy data from RAM to GPU...");
+     cudaMemcpy(StructData_gpu->x, StructData->x, K*sizeof(float), cudaMemcpyHostToDevice);
+	LogSystem::write("   x done...");
+     cudaMemcpy(StructData_gpu->y, StructData->y, K*sizeof(float), cudaMemcpyHostToDevice);
+	LogSystem::write("   y done...");
+     cudaMemcpy(StructData_gpu->z, StructData->z, K*sizeof(float), cudaMemcpyHostToDevice);
+	LogSystem::write("   z done...");
+	LogSystem::write("");
+	LogSystem::write("data transfer finished...");
+	LogSystem::write("");
+
 }
 
 
@@ -146,7 +168,27 @@ void init_StructureData(StructureData* StructData, \
 	allocate_StructureDataRAM(StructData, StructDataProp, InputData);
 	read_StructureData(StructData, StructDataProp, InputData);
 	allocate_StructureDataGPU(StructData, StructData_gpu);
+
+}
+
+void init_StructureDataMemory(StructureData* StructData, \
+                              StructureData* StructData_gpu, \
+                              StructDataProperties* StructDataProp, \
+                              InputFileData* InputData){
+
+	allocate_StructureDataRAM(StructData, StructDataProp, InputData);
+	allocate_StructureDataGPU(StructData, StructData_gpu);
    
+}
+
+void new_read_StructureData(StructureData* StructData, \
+                            StructureData* StructData_gpu, \
+                            StructDataProperties* StructDataProp, \
+                            InputFileData* InputData){
+
+	read_StructureData(StructData, StructDataProp, InputData);
+	copy_StructureDataRAM2GPU(StructData, StructData_gpu);
+
 }
 
 void free_StructureData(StructureData *StructData, \

--- a/src/InputData/StructData/NuMagSANSlib_StructureDataExplorer.h
+++ b/src/InputData/StructData/NuMagSANSlib_StructureDataExplorer.h
@@ -32,8 +32,10 @@ using namespace std;
 struct StructDataProperties{
 
 	string GlobalFilePath;
+	string GlobalFolderPath;
 
 	int Number_Of_Elements;
+	int Number_Of_Files;
 	
 };
 
@@ -49,7 +51,42 @@ void get_GlobalStructDataPath(std::string Local_StructDataPath, StructDataProper
 	//StructDataProp->GlobalFilePath = tmp_string + "/" + Local_StructDataPath;
 	StructDataProp->GlobalFilePath = Local_StructDataPath;
 	LogSystem::write("found Global StructDataPath: " + StructDataProp->GlobalFilePath);
+
+}
+
+void get_GlobalStructDataFolderPath(std::string Local_StructDataFolderPath,
+                                    StructDataProperties* StructDataProp){
+
+    char tmp[PATH_MAX];
+    getcwd(tmp, PATH_MAX);
+
+    std::string tmp_string = tmp;
+
+	//StructDataProp->GlobalFolderPath = tmp_string + "/" + Local_StructDataFolderPath;
+	StructDataProp->GlobalFolderPath = Local_StructDataFolderPath;
+	LogSystem::write("found Global StructDataFolderPath: " + StructDataProp->GlobalFolderPath);
     
+}
+
+std::string StructDataLoopFilePath(StructDataProperties* StructDataProp,
+                                   int StructData_File_Index){
+
+    return StructDataProp->GlobalFolderPath + "/StructData_" + std::to_string(StructData_File_Index) + ".csv";
+}
+
+bool StructFileExists(std::string filename){
+
+    ifstream fin(filename);
+    bool exists = fin.good();
+    fin.close();
+    return exists;
+}
+
+void SetActiveStructDataFile(StructDataProperties* StructDataProp,
+                             int StructData_File_Index){
+
+    StructDataProp->GlobalFilePath = StructDataLoopFilePath(StructDataProp, StructData_File_Index);
+    LogSystem::write("active StructDataPath: " + StructDataProp->GlobalFilePath);
 }
 
 void NumberOfEntriesInStructureFile(int *NumberOfColumns, string filename){
@@ -86,6 +123,8 @@ bool StructData_Observer(std::string Local_StructDataPath, StructDataProperties*
 
 	bool CheckFlag = false;
 
+	StructDataProp->Number_Of_Files = 1;
+
 	// get global path of the MagData directory
 	get_GlobalStructDataPath(Local_StructDataPath, StructDataProp);
 
@@ -104,6 +143,79 @@ bool StructData_Observer(std::string Local_StructDataPath, StructDataProperties*
 	if(StructDataProp->Number_Of_Elements != 0){
 		CheckFlag = true;
 	}
+
+	return CheckFlag;
+
+}
+
+bool StructDataLoop_Observer(std::string Local_StructDataFolderPath,
+                             std::vector<int> StructDataLoop_IndexArray,
+                             StructDataProperties* StructDataProp){
+
+	LogSystem::write("##########################################################################################");
+	LogSystem::write("## Run - Structure Folder Explorer #######################################################");
+	LogSystem::write("##########################################################################################");
+	LogSystem::write("");
+
+	bool CheckFlag = true;
+
+	if(StructDataLoop_IndexArray.empty()){
+		LogSystem::write("Error: StructDataLoop has no active StructData indices.");
+		CheckFlag = false;
+	}
+
+	if(Local_StructDataFolderPath == ""){
+		LogSystem::write("Error: StructDataPath is empty while StructDataLoop is active.");
+		CheckFlag = false;
+	}
+
+	get_GlobalStructDataFolderPath(Local_StructDataFolderPath, StructDataProp);
+
+	StructDataProp->Number_Of_Files = StructDataLoop_IndexArray.size();
+	StructDataProp->Number_Of_Elements = 0;
+
+	for(int k = 0; k < StructDataLoop_IndexArray.size(); k++){
+		int StructData_File_Index = StructDataLoop_IndexArray[k];
+		std::string filename = StructDataLoopFilePath(StructDataProp, StructData_File_Index);
+
+		if(!StructFileExists(filename)){
+			LogSystem::write("Error: missing StructData file: " + filename);
+			CheckFlag = false;
+			continue;
+		}
+
+		int Number_Of_Elements_tmp = 0;
+		NumberOfEntriesInStructureFile(&Number_Of_Elements_tmp, filename);
+
+		LogSystem::write("StructData_" + std::to_string(StructData_File_Index) + ".csv entries: "
+						 + std::to_string(Number_Of_Elements_tmp));
+
+		if(Number_Of_Elements_tmp == 0){
+			LogSystem::write("Error: StructData file contains zero entries: " + filename);
+			CheckFlag = false;
+		}
+
+		if(StructDataProp->Number_Of_Elements == 0){
+			StructDataProp->Number_Of_Elements = Number_Of_Elements_tmp;
+		}else if(StructDataProp->Number_Of_Elements != Number_Of_Elements_tmp){
+			LogSystem::write("Error: StructData files do not contain the same number of entries.");
+			CheckFlag = false;
+		}
+	}
+
+	if(!StructDataLoop_IndexArray.empty()){
+		SetActiveStructDataFile(StructDataProp, StructDataLoop_IndexArray[0]);
+	}
+
+	LogSystem::write("Number of StructData files: " + std::to_string(StructDataProp->Number_Of_Files));
+	LogSystem::write("Number of Entries: " + std::to_string(StructDataProp->Number_Of_Elements));
+	LogSystem::write("");
+
+	LogSystem::write("##########################################################################################");
+	LogSystem::write("## Stop - Structure Folder Explorer ######################################################");
+	LogSystem::write("##########################################################################################");
+	LogSystem::write("");
+	LogSystem::write("");
 
 	return CheckFlag;
 

--- a/src/NuMagSANS.cu
+++ b/src/NuMagSANS.cu
@@ -59,7 +59,13 @@ int main(int argc, char* argv[]){
 	StructDataProperties StructDataProp;
 	bool Check_StructData_Flag;
 	if(InputData.StructData_activate_flag){
-		Check_StructData_Flag = StructData_Observer(InputData.StructDataFilename, &StructDataProp);
+		if(InputData.StructDataLoop_flag){
+			Check_StructData_Flag = StructDataLoop_Observer(InputData.StructDataPath,
+															InputData.StructDataLoop_IndexArray,
+															&StructDataProp);
+		}else{
+			Check_StructData_Flag = StructData_Observer(InputData.StructDataFilename, &StructDataProp);
+		}
 		if(Check_StructData_Flag != true){
 			LogSystem::write(" ->-> Error in StructData!");
 			LogSystem::write("");

--- a/src/NuMagSANSInputTemplate.conf
+++ b/src/NuMagSANSInputTemplate.conf
@@ -15,6 +15,7 @@ NucDataPath = RealSpaceData/NucData;               // foldername where the nucle
 MagDataPath = RealSpaceData/MagData;		      	 // foldername where the magnetization data is stored
 StructDataFilename = RealSpaceData/StructData.csv; // foldername where the structure data is stored
 RotDataFilename = RealSpaceData/RotData.csv;	// foldername where the rotation data is stored
+StructDataPath = RealSpaceData/StructData; // foldername for StructData_1.csv, StructData_2.csv, ... in StructDataLoop mode
 RotDataPath = RealSpaceData/RotData;    // foldername for RotData_1.csv, RotData_2.csv, ... in RotDataLoop mode
 foldernameSANSData = NuMagSANS_Output;    			 // foldername where the SANS data is to be stored
 
@@ -43,6 +44,11 @@ Fourier_Approach = atomistic;	   // (atomistic, micromagnetic)
 Loop_Modus = 0;		// select loop modus with 1, deselect loop modus with 0 (boolean selector)
 Loop_From = 1;		// start index of the parameter loop
 Loop_To = 20; 		// end index of the parameter loop
+
+StructDataLoop = 0;     // select inner structure data loop with 1, deselect with 0
+StructDataLoop_From = 1; // start index for StructData/StructData_#.csv files
+StructDataLoop_To = 1;  // end index for StructData/StructData_#.csv files
+// StructData_User_Selection = {1, 3, 4}; // optional explicit selection of StructData_#.csv files; overrides StructDataLoop_From/To if set
 
 RotDataLoop = 0;        // select inner rotation data loop with 1, deselect with 0
 RotDataLoop_From = 1;   // start index for RotData/RotData_#.csv files

--- a/src/NuMagSANSlib.h
+++ b/src/NuMagSANSlib.h
@@ -84,24 +84,51 @@ void NuMagSANS_Calculator(InputFileData* InputData, \
 	// check memory
 	LogCurrentGPUMemoryDifference(MemoryBeforeRun);
 
-	if(InputData->RotData_activate_flag && InputData->RotDataLoop_flag){
+	bool StructDataLoop_active = InputData->StructData_activate_flag && InputData->StructDataLoop_flag;
+	bool RotDataLoop_active = InputData->RotData_activate_flag && InputData->RotDataLoop_flag;
+
+	int Number_Of_StructData_Runs = StructDataLoop_active ? static_cast<int>(InputData->StructDataLoop_IndexArray.size()) : 1;
+	int Number_Of_RotData_Runs = RotDataLoop_active ? static_cast<int>(InputData->RotDataLoop_IndexArray.size()) : 1;
+
+	bool First_Run = true;
+
+	for(int StructDataLoop_Counter = 0;
+		StructDataLoop_Counter < Number_Of_StructData_Runs;
+		StructDataLoop_Counter++){
+
+		int StructData_File_Index = 0;
+
+		if(StructDataLoop_active){
+			StructData_File_Index = InputData->StructDataLoop_IndexArray[StructDataLoop_Counter];
+
+			LogSystem::write("inner StructData loop active: StructData index "
+			                 + std::to_string(StructData_File_Index));
+
+			SetActiveStructDataFile(StructDataProp, StructData_File_Index);
+			new_read_StructureData(&Data.StructData, &Data.StructData_gpu, StructDataProp, InputData);
+			CheckCUDALastError("reload structure data");
+		}
 
 		for(int RotDataLoop_Counter = 0;
-			RotDataLoop_Counter < InputData->RotDataLoop_IndexArray.size();
+			RotDataLoop_Counter < Number_Of_RotData_Runs;
 			RotDataLoop_Counter++){
 
-			int RotData_File_Index = InputData->RotDataLoop_IndexArray[RotDataLoop_Counter];
+			int RotData_File_Index = 0;
 
-			LogSystem::write("inner RotData loop active: RotData index "
-			                 + std::to_string(RotData_File_Index));
+			if(RotDataLoop_active){
+				RotData_File_Index = InputData->RotDataLoop_IndexArray[RotDataLoop_Counter];
 
-			if(RotDataLoop_Counter != 0){
-				ResetSANSOutputData(InputData, &Data);
+				LogSystem::write("inner RotData loop active: RotData index "
+				                 + std::to_string(RotData_File_Index));
+
+				SetActiveRotDataFile(RotDataProp, RotData_File_Index);
+				new_read_RotationData(&Data.RotData, &Data.RotData_gpu, RotDataProp, InputData);
+				CheckCUDALastError("reload rotation data");
 			}
 
-			SetActiveRotDataFile(RotDataProp, RotData_File_Index);
-			new_read_RotationData(&Data.RotData, &Data.RotData_gpu, RotDataProp, InputData);
-			CheckCUDALastError("reload rotation data");
+			if(!First_Run){
+				ResetSANSOutputData(InputData, &Data);
+			}
 
 			// run gpu kernel
 			SelectKernelRun(InputData, &Data);
@@ -110,21 +137,11 @@ void NuMagSANS_Calculator(InputFileData* InputData, \
 			KernelPostprocessRun(InputData, &Data);
 
 			// export data
-			ExportData(InputData, &Data, Data_File_Index, RotData_File_Index);
+			ExportData(InputData, &Data, Data_File_Index, StructData_File_Index, RotData_File_Index);
 			CheckCUDALastError("export scattering data");
+
+			First_Run = false;
 		}
-
-	}else{
-
-		// run gpu kernel
-		SelectKernelRun(InputData, &Data);
-
-		// run gpu post-processing kernels
-		KernelPostprocessRun(InputData, &Data);
-
-		// export data
-		ExportData(InputData, &Data, Data_File_Index);
-		CheckCUDALastError("export scattering data");
 	}
 
 	// free memory

--- a/src/OutputData/SANSData/NuMagSANSlib_SANSData.h
+++ b/src/OutputData/SANSData/NuMagSANSlib_SANSData.h
@@ -1207,6 +1207,7 @@ void write2CSVtable_ScatteringData(
     InputFileData* InputData,
     ScatteringData* SANSData,
     int MagData_File_Index,
+	int StructData_File_Index = 0,
 	int RotData_File_Index = 0
 ){
     LogSystem::write("");
@@ -1215,6 +1216,10 @@ void write2CSVtable_ScatteringData(
     std::string target_foldername =
         InputData->SANSDataFoldername + "/SANS_" +
         std::to_string(MagData_File_Index) + "/";
+
+	if(StructData_File_Index > 0){
+		target_foldername += "StructData_" + std::to_string(StructData_File_Index) + "/";
+	}
 
 	if(RotData_File_Index > 0){
 		target_foldername += "RotData_" + std::to_string(RotData_File_Index) + "/";

--- a/src/OutputData/SpectralData/NuMagSANSlib_SpectralData.h
+++ b/src/OutputData/SpectralData/NuMagSANSlib_SpectralData.h
@@ -483,6 +483,7 @@ void write2CSV_SpectralData(
     InputFileData* InputData,
     SpectralData* SpecData,
     int MagData_File_Index,
+    int StructData_File_Index = 0,
     int RotData_File_Index = 0)
 {
     LogSystem::write("");
@@ -492,6 +493,10 @@ void write2CSV_SpectralData(
         InputData->SANSDataFoldername +
         "/SANS_" + std::to_string(MagData_File_Index) +
         "/";
+
+    if(StructData_File_Index > 0){
+        baseFolder += "StructData_" + std::to_string(StructData_File_Index) + "/";
+    }
 
     if(RotData_File_Index > 0){
         baseFolder += "RotData_" + std::to_string(RotData_File_Index) + "/";
@@ -640,4 +645,3 @@ void free_SpectralData(SpectralData* S, \
     cudaDeviceSynchronize();
 
 }
-

--- a/src/wrapper/NuMagSANSlib_ExportData.h
+++ b/src/wrapper/NuMagSANSlib_ExportData.h
@@ -5,6 +5,7 @@ inline void ExportDataMulti(InputFileData* InputData,
 							ScatteringData* SANSData, ScatteringData* SANSData_gpu,
 							SpectralData* SpecData, SpectralData* SpecData_gpu,
 							int Data_File_Index,
+							int StructData_File_Index = 0,
 							int RotData_File_Index = 0){
 
 	// copy scattering data from GPU to RAM ###################################################
@@ -15,7 +16,7 @@ inline void ExportDataMulti(InputFileData* InputData,
 	scale_ScatteringData(ScalFactors, SANSData, InputData);
 
 	// write scattering data to csv files #####################################################
-	write2CSVtable_ScatteringData(InputData, SANSData, Data_File_Index, RotData_File_Index);
+	write2CSVtable_ScatteringData(InputData, SANSData, Data_File_Index, StructData_File_Index, RotData_File_Index);
 
 	if(InputData->AngularSpec_activate_flag){
 		// copy spectral data from GPU to RAM #################################################
@@ -25,7 +26,7 @@ inline void ExportDataMulti(InputFileData* InputData,
 		scale_SpectralData(ScalFactors, SpecData, InputData);
 	
 		// write spectral data to csv files ###################################################
-		write2CSV_SpectralData(InputData, SpecData, Data_File_Index, RotData_File_Index);
+		write2CSV_SpectralData(InputData, SpecData, Data_File_Index, StructData_File_Index, RotData_File_Index);
 	}
 }
 
@@ -33,6 +34,7 @@ inline void ExportDataMulti(InputFileData* InputData,
 inline void ExportData(InputFileData* InputData, 
 	                   NuMagSANSData* Data, 
 					   int Data_File_Index,
+					   int StructData_File_Index = 0,
 					   int RotData_File_Index = 0){
 
 	ExportDataMulti(InputData,
@@ -40,6 +42,7 @@ inline void ExportData(InputFileData* InputData,
 					&Data->SANSData, &Data->SANSData_gpu,
 					&Data->SpecData, &Data->SpecData_gpu,
 					Data_File_Index,
+					StructData_File_Index,
 					RotData_File_Index);
 
 }

--- a/src/wrapper/NuMagSANSlib_InitializeData.h
+++ b/src/wrapper/NuMagSANSlib_InitializeData.h
@@ -29,7 +29,11 @@ inline void InitializeDataMulti(InputFileData* InputData,
 
 	// initialize structure data ##############################################################
 	if(InputData->StructData_activate_flag){
-		init_StructureData(StructData, StructData_gpu, StructDataProp, InputData);
+		if(InputData->StructDataLoop_flag){
+			init_StructureDataMemory(StructData, StructData_gpu, StructDataProp, InputData);
+		}else{
+			init_StructureData(StructData, StructData_gpu, StructDataProp, InputData);
+		}
 		CheckCUDALastError("initialize structure data");
 		//disp_StructureData(StructData);
 	}


### PR DESCRIPTION
## Summary

This PR adds an inner `StructDataLoop`, analogous to the existing `RotDataLoop`.

It enables NuMagSANS to keep the selected local `MagData`/`NucData` fixed while sweeping over several object-center translation files:

```text
RealSpaceData/
  StructData/
    StructData_1.csv
    StructData_2.csv
    StructData_3.csv
```

If `StructDataLoop` and `RotDataLoop` are both active, NuMagSANS evaluates them as nested metadata loops:

```text
Data file index
  -> StructData_#
       -> RotData_#
```

## Changes

- Added new input parameters:
  - `StructDataPath`
  - `StructDataLoop`
  - `StructDataLoop_From`
  - `StructDataLoop_To`
  - `StructData_User_Selection`
- Added `StructDataLoop` parsing and index-array handling in the input interpreter.
- Added a structure-folder explorer for `StructData_#.csv` files.
- Added active StructData file selection via `SetActiveStructDataFile(...)`.
- Added StructData reload support:
  - allocate once
  - read new `StructData_#.csv`
  - copy updated data to GPU
- Extended the main NuMagSANS orchestration:
  - `StructDataLoop` is the outer metadata loop
  - `RotDataLoop` remains the inner metadata loop
- Extended output folder nesting:
  - `SANS_1/StructData_2/`
  - `SANS_1/RotData_3/`
  - `SANS_1/StructData_2/RotData_3/`
- Updated the Python facade `NuMagSANS.write_config(...)` to support the new parameters.
- Updated `NuMagSANSInputTemplate.conf`.
- Updated Getting Started documentation:
  - `ParameterOverview`
  - `SimulationScenarios`
- Extended `examples/example2` to test the new nested loop behavior with:
  - 3 StructData files
  - 4 RotData files
  - 5 random iterations

## Testing

Local checks:

```bash
git diff --check
/Users/michael/pixi_science_env-main/.pixi/envs/default/bin/python -m py_compile examples/example2/NuMagSANSrun.py
```

Config generation was also checked with the Pixi Python environment.