### PR TITLE
implementation of replication import mode

### DIFF
--- a/NuMagSANS/NuMagSANS.py
+++ b/NuMagSANS/NuMagSANS.py
@@ -89,6 +89,10 @@ class NuMagSANS:
         StructData_activate=0,
         RotData_activate=0,
         FastLoad=0,
+        NucData_ReplicationImport=0,
+        NucData_NumberOfReplications=1,
+        MagData_ReplicationImport=0,
+        MagData_NumberOfReplications=1,
         Exclude_Zero_Moments=0,
 
         # fourier
@@ -174,6 +178,10 @@ class NuMagSANS:
             W("StructData_activate", StructData_activate)
             W("RotData_activate", RotData_activate)
             W("FastLoad", FastLoad)
+            W("NucData_ReplicationImport", NucData_ReplicationImport)
+            W("NucData_NumberOfReplications", NucData_NumberOfReplications)
+            W("MagData_ReplicationImport", MagData_ReplicationImport)
+            W("MagData_NumberOfReplications", MagData_NumberOfReplications)
             W("Exclude_Zero_Moments", Exclude_Zero_Moments)
 
             # ---------------------------

--- a/docs/GettingStarted/ParameterOverview.rst
+++ b/docs/GettingStarted/ParameterOverview.rst
@@ -139,6 +139,31 @@ local object data without rewriting the object files.
     magnetic or nuclear data files have the same number of rows. Different
     objects may still have different numbers of rows.
 
+``MagData_ReplicationImport``
+    Default value 0
+
+    If set to ``1``, NuMagSANS expects one physical magnetic template object in
+    ``MagData`` and replicates it internally during import. The kernels receive
+    the same in-memory structure as for explicitly stored object folders.
+
+``MagData_NumberOfReplications``
+    Default value 1
+
+    Effective number of magnetic objects generated from the single physical
+    template object when ``MagData_ReplicationImport`` is active.
+
+``NucData_ReplicationImport``
+    Default value 0
+
+    If set to ``1``, NuMagSANS expects one physical nuclear template object in
+    ``NucData`` and replicates it internally during import.
+
+``NucData_NumberOfReplications``
+    Default value 1
+
+    Effective number of nuclear objects generated from the single physical
+    template object when ``NucData_ReplicationImport`` is active.
+
 ``Exclude_Zero_Moments``
     Default value 0
 

--- a/docs/GettingStarted/SimulationScenarios.rst
+++ b/docs/GettingStarted/SimulationScenarios.rst
@@ -76,6 +76,12 @@ through ``Loop_Modus``. If this execution-layer distinction is counted as a
 separate binary choice, the ``27`` data-layer scenarios become ``54`` basic
 execution scenarios.
 
+Replication import is an additional import-layer option for selected
+scenarios. It does not add new kernels or a new mathematical model. Instead,
+one physical local object is replicated internally during data loading so that
+the GPU receives the same object-wise memory layout as for explicitly stored
+object folders.
+
 The following sections do not document every possible combination separately.
 Instead, they describe representative scenarios from which the remaining
 combinations can be derived.
@@ -434,26 +440,57 @@ The following consistency rules should be satisfied:
 - For a selected data-file index ``k``, each active object folder should
   contain the corresponding ``m_k.csv`` or ``n_k.csv`` file.
 - If ``StructData`` is active without ``StructDataLoop``, the number of rows in
-  ``StructData.csv`` must match the number of local objects.
+  ``StructData.csv`` must match the effective number of objects.
 - If ``StructDataLoop`` is active, every selected ``StructData_#.csv`` file
-  must contain one row per local object.
+  must contain one row per effective object.
 - If ``RotData`` is active without ``RotDataLoop``, the number of rows in
-  ``RotData.csv`` must match the number of local objects.
+  ``RotData.csv`` must match the effective number of objects.
 - If ``RotDataLoop`` is active, every selected ``RotData_#.csv`` file must
-  contain one row per local object.
+  contain one row per effective object.
 - If both ``StructData`` and ``RotData`` are active, both metadata layers must
   contain the same number of object entries.
 - Files are whitespace-separated and do not use CSV headers.
 
 
-Future Extension: Replication Import
-------------------------------------
+Replication Import
+------------------
 
-A planned extension is a replication-import mode. In this mode, one local
-object would be read once and replicated internally in RAM before GPU upload.
-The kernels would then receive the same in-memory structure as for a fully
-materialized dataset, while avoiding thousands of duplicated object files on
-disk.
+Replication import is useful when many objects share the same local real-space
+data. Instead of storing thousands of duplicated object folders, one physical
+template object is stored and NuMagSANS replicates it internally during import.
 
-This mode is not part of the current input format, but it follows naturally
-from the same separation between local object data and assembly metadata.
+For magnetic data, the input may contain only one physical object:
+
+.. code-block:: text
+
+   RealSpaceData/
+     MagData/
+       Object_1/
+         m_1.csv
+     StructData.csv
+     RotData.csv
+
+The corresponding configuration is:
+
+.. code-block:: conf
+
+   MagData_activate = 1;
+   MagData_ReplicationImport = 1;
+   MagData_NumberOfReplications = 5000;
+
+``MagData_NumberOfReplications`` is the effective object count. In the example
+above, NuMagSANS creates the same in-memory representation that would result
+from explicitly storing ``Object_1`` through ``Object_5000``. If ``StructData``
+or ``RotData`` is active, the number of entries in those metadata files must
+match the number of replications.
+
+The same mechanism is available for nuclear data through:
+
+.. code-block:: conf
+
+   NucData_activate = 1;
+   NucData_ReplicationImport = 1;
+   NucData_NumberOfReplications = 5000;
+
+Replication import only changes the input/read layer. The scattering kernels,
+kernel selection logic, and output organization remain unchanged.

--- a/src/InputData/MagData/NuMagSANSlib_MagData.h
+++ b/src/InputData/MagData/NuMagSANSlib_MagData.h
@@ -63,7 +63,7 @@ void allocate_MagnetizationDataRAM(MagnetizationData* MagData, \
 	 unsigned long int K = MagDataProp->Number_Of_SubFolders;
      unsigned long int TotalAtomNumber = 0;
 	 if(ExcludeZeroMoments_flag){
-     	TotalAtomNumber = MagDataProp->TotalNZMAtomNumber[MagData_File_Index];
+		TotalAtomNumber = MagDataProp->TotalNZMAtomNumber[MagData_File_Index-1];
      } else{
 		TotalAtomNumber = MagDataProp->TotalAtomNumber[MagData_File_Index-1];
      }
@@ -180,9 +180,9 @@ void read_MagnetizationData(MagnetizationData* MagData, \
      unsigned long int K = *MagData->K;
      bool ExcludeZeroMoments_flag = InputData->ExcludeZeroMoments_flag;
 
-	 for(int i = 0; i < 9; i++){
-	 	MagData->RotMat[i] = InputData->RotMat[i];
-	 }
+	for(int i = 0; i < 9; i++){
+		MagData->RotMat[i] = InputData->RotMat[i];
+	}
 
      string filename;
      unsigned long int n = 0;
@@ -277,6 +277,133 @@ void read_MagnetizationData(MagnetizationData* MagData, \
  
  }
 
+
+
+ void replication_read_MagnetizationData(MagnetizationData* MagData, \
+                                        MagDataProperties* MagDataProp, \
+                                        InputFileData* InputData, \
+                                        int MagData_File_Index){
+
+
+	LogSystem::write("");
+	LogSystem::write("read replicated magnetization data to RAM...");
+
+     unsigned long int K = *MagData->K;
+     bool ExcludeZeroMoments_flag = InputData->ExcludeZeroMoments_flag;
+
+	for(int i = 0; i < 9; i++){
+		MagData->RotMat[i] = InputData->RotMat[i];
+	}
+
+     string filename;
+     unsigned long int n = 0;
+     float x_buf, y_buf, z_buf, mx_buf, my_buf, mz_buf;
+     ifstream fin;
+     float x_mean = 0.0;
+     float y_mean = 0.0;
+     float z_mean = 0.0;
+
+     unsigned long int N_cum = 0;   // cummulative counter
+     unsigned long int N_act = 0;   // actual number of atoms per replicated object
+
+     if(ExcludeZeroMoments_flag){
+         N_act = MagData->NumberOfNonZeroMoments[0];
+     }else{
+         N_act = MagData->NumberOfElements[0];
+     }
+
+     filename = MagDataProp->GlobalFolderPath + "/" + MagDataProp->SubFolderNames_Nom + "_1" \
+              + "/" + MagDataProp->SubFolder_FileNames_Nom + "_" + to_string(MagData_File_Index)\
+              + "." + MagDataProp->SubFolder_FileNames_Type;
+
+     LogSystem::write(filename);
+
+     std::vector<float> x_template(N_act);
+     std::vector<float> y_template(N_act);
+     std::vector<float> z_template(N_act);
+     std::vector<float> mx_template(N_act);
+     std::vector<float> my_template(N_act);
+     std::vector<float> mz_template(N_act);
+
+     fin.open(filename);
+     n = 0;
+     x_mean = 0.0;
+     y_mean = 0.0;
+     z_mean = 0.0;
+
+     if(ExcludeZeroMoments_flag){
+		while(fin >> x_buf >> y_buf >> z_buf >> mx_buf >> my_buf >> mz_buf){
+			if(mx_buf != 0.0 || my_buf != 0.0 || mz_buf != 0.0){
+				x_template[n] = x_buf * InputData->XYZ_Unit_Factor;
+				y_template[n] = y_buf * InputData->XYZ_Unit_Factor;
+				z_template[n] = z_buf * InputData->XYZ_Unit_Factor;
+				mx_template[n] = mx_buf;
+				my_template[n] = my_buf;
+				mz_template[n] = mz_buf;
+
+				x_mean += x_template[n]/N_act;
+				y_mean += y_template[n]/N_act;
+				z_mean += z_template[n]/N_act;
+
+				n += 1;
+			}
+		}
+     } else{
+		while(fin >> x_buf >> y_buf >> z_buf >> mx_buf >> my_buf >> mz_buf){
+	        x_template[n] = x_buf * InputData->XYZ_Unit_Factor;
+	        y_template[n] = y_buf * InputData->XYZ_Unit_Factor;
+	        z_template[n] = z_buf * InputData->XYZ_Unit_Factor;
+	        mx_template[n] = mx_buf;
+	        my_template[n] = my_buf;
+	        mz_template[n] = mz_buf;
+
+	        x_mean += x_template[n]/N_act;
+	        y_mean += y_template[n]/N_act;
+	        z_mean += z_template[n]/N_act;
+
+			n += 1;
+		}
+     }
+
+     fin.close();
+
+     for(unsigned long int l = 0; l < N_act; l++){
+         x_template[l] = x_template[l] - x_mean;
+         y_template[l] = y_template[l] - y_mean;
+         z_template[l] = z_template[l] - z_mean;
+     }
+
+     for(unsigned long int k = 1; k <= K; k++){
+
+         MagData->N_act[k-1] = N_act;
+
+         for(unsigned long int l = 0; l < N_act; l++){
+             MagData->x[l + N_cum] = x_template[l];
+             MagData->y[l + N_cum] = y_template[l];
+             MagData->z[l + N_cum] = z_template[l];
+             MagData->mx[l + N_cum] = mx_template[l];
+             MagData->my[l + N_cum] = my_template[l];
+             MagData->mz[l + N_cum] = mz_template[l];
+         }
+
+        // update of the cummulative counter
+        N_cum += N_act;
+        if(k<K){
+            MagData->N_cum[k] = N_cum;
+        }
+	LogSystem::write("replicated object " + std::to_string(k) + ": N_act: " + std::to_string(N_act) + ", " + "N_cum: " + std::to_string(N_cum));
+      }
+
+      *MagData->N_avg = (unsigned long int) (((float)N_cum)/((float) K));
+	LogSystem::write("N_avg: " + to_string(*MagData->N_avg));
+	LogSystem::write("read replicated (x, y, z, mx, my, mz) data to RAM finished...");
+
+
+ }
+
+
+
+
 void init_MagnetizationData(MagnetizationData* MagData, \
                   MagnetizationData* MagData_gpu, \
                   MagDataProperties* MagDataProp, \
@@ -284,7 +411,11 @@ void init_MagnetizationData(MagnetizationData* MagData, \
                   int MagData_File_Index){
 
 	allocate_MagnetizationDataRAM(MagData, MagDataProp, InputData, MagData_File_Index);
-	read_MagnetizationData(MagData, MagDataProp, InputData, MagData_File_Index);
+	if(InputData->MagData_ReplicationImport_flag){
+		replication_read_MagnetizationData(MagData, MagDataProp, InputData, MagData_File_Index);
+	}else{
+		read_MagnetizationData(MagData, MagDataProp, InputData, MagData_File_Index);
+	}
 	allocate_MagnetizationDataGPU(MagData, MagData_gpu, MagData_File_Index);
    
 }

--- a/src/InputData/MagData/NuMagSANSlib_MagDataExplorer.h
+++ b/src/InputData/MagData/NuMagSANSlib_MagDataExplorer.h
@@ -308,11 +308,57 @@ void CountAtomNumbers_MagData(MagDataProperties* MagDataProp){
 	}
 }
 
+bool ApplyReplicationImport_MagData(MagDataProperties* MagDataProp, int NumberOfReplications){
+
+	if(NumberOfReplications <= 0){
+		LogSystem::write(" ->-> Error: MagData_NumberOfReplications must be larger than zero.");
+		return false;
+	}
+
+	if(MagDataProp->Number_Of_SubFolders != 1){
+		LogSystem::write(" ->-> Error: MagData replication import requires exactly one physical template object.");
+		LogSystem::write("Physical MagData object folders: " + std::to_string(MagDataProp->Number_Of_SubFolders));
+		return false;
+	}
+
+	LogSystem::write("MagData replication import active.");
+	LogSystem::write("Physical MagData object folders: 1");
+	LogSystem::write("Effective MagData object count: " + std::to_string(NumberOfReplications));
+
+	std::vector<int> TemplateNumberOfElements(MagDataProp->Number_Of_Files_In_SubFolder);
+	std::vector<int> TemplateNumberOfNonZeroMoments(MagDataProp->Number_Of_Files_In_SubFolder);
+
+	for(int j = 0; j < MagDataProp->Number_Of_Files_In_SubFolder; j++){
+		TemplateNumberOfElements[j] = MagDataProp->NumberOfElements[0][j];
+		TemplateNumberOfNonZeroMoments[j] = MagDataProp->NumberOfNonZeroMoments[0][j];
+	}
+
+	delete[] MagDataProp->NumberOfElements[0];
+	delete[] MagDataProp->NumberOfElements;
+	delete[] MagDataProp->NumberOfNonZeroMoments[0];
+	delete[] MagDataProp->NumberOfNonZeroMoments;
+
+	MagDataProp->Number_Of_SubFolders = NumberOfReplications;
+	MagDataProp->NumberOfElements = new int*[MagDataProp->Number_Of_SubFolders];
+	MagDataProp->NumberOfNonZeroMoments = new int*[MagDataProp->Number_Of_SubFolders];
+
+	for(int i = 0; i < MagDataProp->Number_Of_SubFolders; i++){
+		MagDataProp->NumberOfElements[i] = new int[MagDataProp->Number_Of_Files_In_SubFolder];
+		MagDataProp->NumberOfNonZeroMoments[i] = new int[MagDataProp->Number_Of_Files_In_SubFolder];
+		for(int j = 0; j < MagDataProp->Number_Of_Files_In_SubFolder; j++){
+			MagDataProp->NumberOfElements[i][j] = TemplateNumberOfElements[j];
+			MagDataProp->NumberOfNonZeroMoments[i][j] = TemplateNumberOfNonZeroMoments[j];
+		}
+	}
+
+	return true;
+}
+
 
 
 
 // Routine that checks number of subfolders in MagData directory
-bool MagData_Observer(std::string Local_MagDataPath, MagDataProperties*MagDataProp, bool FastLoad){
+bool MagData_Observer(std::string Local_MagDataPath, MagDataProperties*MagDataProp, InputFileData* InputData){
 
 	//cout << "##########################################################################################" << "\n";
 	//cout << "## Run - MagData Directory Explorer ######################################################" << "\n";
@@ -321,7 +367,7 @@ bool MagData_Observer(std::string Local_MagDataPath, MagDataProperties*MagDataPr
 	LogSystem::write("##########################################################################################");
 	LogSystem::write("## Run - MagData Directory Explorer ######################################################");
 	LogSystem::write("##########################################################################################");
-	LogSystem::write("FastLoad mode: " + std::string(FastLoad ? "true" : "false"));
+	LogSystem::write("FastLoad mode: " + std::string(InputData->FastLoad_flag ? "true" : "false"));
 
 	bool CheckFlag = false;
 
@@ -335,8 +381,12 @@ bool MagData_Observer(std::string Local_MagDataPath, MagDataProperties*MagDataPr
 	bool Subfolder_Elements_CheckFlag = check_Subfolder_FileNames_MagData(MagDataProp);
 
 
-	bool FileDimensions_CheckFlag = check_FileDimensions_MagData(MagDataProp, FastLoad);
+	bool FileDimensions_CheckFlag = check_FileDimensions_MagData(MagDataProp, InputData->FastLoad_flag);
 
+	bool ReplicationImport_CheckFlag = true;
+	if(InputData->MagData_ReplicationImport_flag){
+		ReplicationImport_CheckFlag = ApplyReplicationImport_MagData(MagDataProp, InputData->MagData_NumberOfReplications);
+	}
 
 	CountAtomNumbers_MagData(MagDataProp);
 
@@ -353,7 +403,7 @@ bool MagData_Observer(std::string Local_MagDataPath, MagDataProperties*MagDataPr
 	//cout << "## Stop - MagData Directory Explorer #####################################################" << "\n";
 	//cout << "##########################################################################################" << "\n\n";
 
-	if(Subfolder_CheckFlag && Subfolder_Elements_CheckFlag && FileDimensions_CheckFlag){
+	if(Subfolder_CheckFlag && Subfolder_Elements_CheckFlag && FileDimensions_CheckFlag && ReplicationImport_CheckFlag){
 		CheckFlag = true;
 	}
 

--- a/src/InputData/NuMagSANSlib_InputFileInterpreter.h
+++ b/src/InputData/NuMagSANSlib_InputFileInterpreter.h
@@ -106,6 +106,18 @@ struct InputFileData{
 	/// Skip repeated MagData dimension checks for faster data import
 	bool FastLoad_flag = false;
 
+	/// Replicate a single local nuclear object during import
+	bool NucData_ReplicationImport_flag = false;
+
+	/// Effective number of nuclear objects generated from the single template object
+	int NucData_NumberOfReplications = 1;
+
+	/// Replicate a single local magnetic object during import
+	bool MagData_ReplicationImport_flag = false;
+
+	/// Effective number of magnetic objects generated from the single template object
+	int MagData_NumberOfReplications = 1;
+
     /// Output directory for computed SANS data
 	string SANSDataFoldername;
 
@@ -580,6 +592,8 @@ bool ReadCSV__Input_File_Interpreter(string filename, InputFileData*InputData){
 		{"StructDataLoop", &InputData->StructDataLoop_flag, false},
 		{"RotDataLoop", &InputData->RotDataLoop_flag, false},
 		{"FastLoad", &InputData->FastLoad_flag, false},
+		{"NucData_ReplicationImport", &InputData->NucData_ReplicationImport_flag, false},
+		{"MagData_ReplicationImport", &InputData->MagData_ReplicationImport_flag, false},
 		{"Exclude_Zero_Moments", &InputData->ExcludeZeroMoments_flag, true},
 		{"Angular_Spec", &InputData->AngularSpec_activate_flag, true},
 		{"Fourier_Gamma", &InputData->output_fourier_correlation_matrix_flag, true}
@@ -595,6 +609,8 @@ bool ReadCSV__Input_File_Interpreter(string filename, InputFileData*InputData){
 		{"StructDataLoop_To", &InputData->StructDataLoop_To, false},
 		{"RotDataLoop_From", &InputData->RotDataLoop_From, false},
 		{"RotDataLoop_To", &InputData->RotDataLoop_To, false},
+		{"NucData_NumberOfReplications", &InputData->NucData_NumberOfReplications, false},
+		{"MagData_NumberOfReplications", &InputData->MagData_NumberOfReplications, false},
 		{"Number_Of_q_Points", &InputData->N_q, true},
 		{"Number_Of_theta_Points", &InputData->N_theta, true},
 		{"Number_Of_r_Points", &InputData->N_r, true},
@@ -803,6 +819,24 @@ bool ReadCSV__Input_File_Interpreter(string filename, InputFileData*InputData){
 		LogSystem::write("Polarization is automatically normalized to 1!");
 	}
 
+	bool ReplicationImport_CheckFlag = true;
+	if(InputData->MagData_ReplicationImport_flag && !InputData->MagData_activate_flag){
+		LogSystem::write("Error: MagData_ReplicationImport requires MagData_activate = 1.");
+		ReplicationImport_CheckFlag = false;
+	}
+	if(InputData->NucData_ReplicationImport_flag && !InputData->NucData_activate_flag){
+		LogSystem::write("Error: NucData_ReplicationImport requires NucData_activate = 1.");
+		ReplicationImport_CheckFlag = false;
+	}
+	if(InputData->MagData_ReplicationImport_flag && InputData->MagData_NumberOfReplications <= 0){
+		LogSystem::write("Error: MagData_NumberOfReplications must be larger than zero.");
+		ReplicationImport_CheckFlag = false;
+	}
+	if(InputData->NucData_ReplicationImport_flag && InputData->NucData_NumberOfReplications <= 0){
+		LogSystem::write("Error: NucData_NumberOfReplications must be larger than zero.");
+		ReplicationImport_CheckFlag = false;
+	}
+
 
 
 	LogSystem::write("##########################################################################################");
@@ -836,6 +870,6 @@ bool ReadCSV__Input_File_Interpreter(string filename, InputFileData*InputData){
 		LogSystem::write(" ->-> Error in input file!");
 	}
 
-	return ok;
+	return ok && ReplicationImport_CheckFlag;
 
 }

--- a/src/InputData/NucData/NuMagSANSlib_NucData.h
+++ b/src/InputData/NucData/NuMagSANSlib_NucData.h
@@ -220,6 +220,90 @@ void read_NuclearData(NuclearData* NucData, \
 
 }
 
+void replication_read_NuclearData(NuclearData* NucData, \
+                                  NucDataProperties* NucDataProp, \
+                                  InputFileData* InputData, \
+                                  int NucData_File_Index){
+
+	LogSystem::write("");
+	LogSystem::write("load replicated NucData...");
+
+      unsigned long int K = *NucData->K;
+
+      for(int i = 0; i < 9; i++){
+         NucData->RotMat[i] = InputData->RotMat[i];
+      }
+
+      string filename;
+      unsigned long int n = 0;
+      float x_buf, y_buf, z_buf, Nuc_buf;
+      ifstream fin;
+      float x_mean = 0.0;
+      float y_mean = 0.0;
+      float z_mean = 0.0;
+
+      unsigned long int N_act = NucData->NumberOfElements[0];
+      unsigned long int N_cum = 0;
+
+      filename = NucDataProp->GlobalFolderPath + "/" + NucDataProp->SubFolderNames_Nom + "_1" \
+               + "/" + NucDataProp->SubFolder_FileNames_Nom + "_" + to_string(NucData_File_Index)\
+               + "." + NucDataProp->SubFolder_FileNames_Type;
+
+	LogSystem::write(filename);
+
+      std::vector<float> x_template(N_act);
+      std::vector<float> y_template(N_act);
+      std::vector<float> z_template(N_act);
+      std::vector<float> nuc_template(N_act);
+
+      fin.open(filename);
+      n = 0;
+
+      while(fin >> x_buf >> y_buf >> z_buf >> Nuc_buf){
+
+              x_template[n] = x_buf * InputData->XYZ_Unit_Factor;
+              y_template[n] = y_buf * InputData->XYZ_Unit_Factor;
+              z_template[n] = z_buf * InputData->XYZ_Unit_Factor;
+              nuc_template[n] = Nuc_buf;
+
+              x_mean += x_template[n]/N_act;
+              y_mean += y_template[n]/N_act;
+              z_mean += z_template[n]/N_act;
+
+              n += 1;
+      }
+      fin.close();
+
+      for(unsigned long int l = 0; l < N_act; l++){
+          x_template[l] = x_template[l] - x_mean;
+          y_template[l] = y_template[l] - y_mean;
+          z_template[l] = z_template[l] - z_mean;
+      }
+
+      for(unsigned long int k = 1; k <= K; k++){
+
+          NucData->N_act[k-1] = N_act;
+
+          for(unsigned long int l = 0; l < N_act; l++){
+              NucData->x[l + N_cum] = x_template[l];
+              NucData->y[l + N_cum] = y_template[l];
+              NucData->z[l + N_cum] = z_template[l];
+              NucData->Nuc[l + N_cum] = nuc_template[l];
+          }
+
+          N_cum += N_act;
+          if(k<K){
+              NucData->N_cum[k] = N_cum;
+          }
+	LogSystem::write("replicated object " + std::to_string(k) + ": N_act: " + std::to_string(N_act) + ", " + "N_cum: " + std::to_string(N_cum));
+       }
+
+      *NucData->N_avg = (unsigned long int) (((float)N_cum)/((float) K));
+	LogSystem::write("N_avg: " + std::to_string(*NucData->N_avg));
+	LogSystem::write("read replicated (x,y,z,n) data finished...");
+
+}
+
 
 
 
@@ -230,7 +314,11 @@ void init_NuclearData(NuclearData* NucData, \
                    	  int NucData_File_Index){
 
      allocate_NuclearDataRAM(NucData, NucDataProp, NucData_File_Index);
-     read_NuclearData(NucData, NucDataProp, InputData, NucData_File_Index);
+     if(InputData->NucData_ReplicationImport_flag){
+        replication_read_NuclearData(NucData, NucDataProp, InputData, NucData_File_Index);
+     }else{
+        read_NuclearData(NucData, NucDataProp, InputData, NucData_File_Index);
+     }
      allocate_NuclearDataGPU(NucData, NucData_gpu, NucData_File_Index);
 }
 
@@ -290,5 +378,3 @@ void disp_NuclearData(NuclearData *NucData){
               << "\n";
      }
 }
-
-

--- a/src/InputData/NucData/NuMagSANSlib_NucDataExplorer.h
+++ b/src/InputData/NucData/NuMagSANSlib_NucDataExplorer.h
@@ -249,15 +249,54 @@ void CountAtomNumbers_NucData(NucDataProperties* NucDataProp){
 	}
 }
 
+bool ApplyReplicationImport_NucData(NucDataProperties* NucDataProp, int NumberOfReplications){
+
+	if(NumberOfReplications <= 0){
+		LogSystem::write(" ->-> Error: NucData_NumberOfReplications must be larger than zero.");
+		return false;
+	}
+
+	if(NucDataProp->Number_Of_SubFolders != 1){
+		LogSystem::write(" ->-> Error: NucData replication import requires exactly one physical template object.");
+		LogSystem::write("Physical NucData object folders: " + std::to_string(NucDataProp->Number_Of_SubFolders));
+		return false;
+	}
+
+	LogSystem::write("NucData replication import active.");
+	LogSystem::write("Physical NucData object folders: 1");
+	LogSystem::write("Effective NucData object count: " + std::to_string(NumberOfReplications));
+
+	std::vector<int> TemplateNumberOfElements(NucDataProp->Number_Of_Files_In_SubFolder);
+
+	for(int j = 0; j < NucDataProp->Number_Of_Files_In_SubFolder; j++){
+		TemplateNumberOfElements[j] = NucDataProp->NumberOfElements[0][j];
+	}
+
+	delete[] NucDataProp->NumberOfElements[0];
+	delete[] NucDataProp->NumberOfElements;
+
+	NucDataProp->Number_Of_SubFolders = NumberOfReplications;
+	NucDataProp->NumberOfElements = new int*[NucDataProp->Number_Of_SubFolders];
+
+	for(int i = 0; i < NucDataProp->Number_Of_SubFolders; i++){
+		NucDataProp->NumberOfElements[i] = new int[NucDataProp->Number_Of_Files_In_SubFolder];
+		for(int j = 0; j < NucDataProp->Number_Of_Files_In_SubFolder; j++){
+			NucDataProp->NumberOfElements[i][j] = TemplateNumberOfElements[j];
+		}
+	}
+
+	return true;
+}
+
 
 
 // Routine that checks number of subfolders in MagData directory
-bool NucData_Observer(std::string Local_NucDataPath, NucDataProperties*NucDataProp, bool FastLoad){
+bool NucData_Observer(std::string Local_NucDataPath, NucDataProperties*NucDataProp, InputFileData* InputData){
 
 	LogSystem::write("##########################################################################################");
 	LogSystem::write("## Run - NucData Directory Explorer ######################################################");
 	LogSystem::write("##########################################################################################");
-	LogSystem::write("FastLoad mode: " + std::string(FastLoad ? "true" : "false"));
+	LogSystem::write("FastLoad mode: " + std::string(InputData->FastLoad_flag ? "true" : "false"));
 	LogSystem::write("");
 
      bool CheckFlag = false;
@@ -271,7 +310,12 @@ bool NucData_Observer(std::string Local_NucDataPath, NucDataProperties*NucDataPr
      // Check the files in each subfolder
      bool Subfolder_Elements_CheckFlag = check_Subfolder_FileNames_NucData(NucDataProp);
 
-     bool FileDimensions_CheckFlag = check_FileDimensions_NucData(NucDataProp, FastLoad);
+     bool FileDimensions_CheckFlag = check_FileDimensions_NucData(NucDataProp, InputData->FastLoad_flag);
+
+     bool ReplicationImport_CheckFlag = true;
+     if(InputData->NucData_ReplicationImport_flag){
+        ReplicationImport_CheckFlag = ApplyReplicationImport_NucData(NucDataProp, InputData->NucData_NumberOfReplications);
+     }
 
      CountAtomNumbers_NucData(NucDataProp);
 
@@ -284,7 +328,7 @@ bool NucData_Observer(std::string Local_NucDataPath, NucDataProperties*NucDataPr
 	LogSystem::write("##########################################################################################");
 	LogSystem::write("");
 
-     if(Subfolder_CheckFlag && Subfolder_Elements_CheckFlag && FileDimensions_CheckFlag){
+     if(Subfolder_CheckFlag && Subfolder_Elements_CheckFlag && FileDimensions_CheckFlag && ReplicationImport_CheckFlag){
          CheckFlag = true;
      }
 

--- a/src/NuMagSANS.cu
+++ b/src/NuMagSANS.cu
@@ -33,7 +33,7 @@ int main(int argc, char* argv[]){
 	MagDataProperties MagDataProp;
 	bool Check_MagData_Flag;
 	if(InputData.MagData_activate_flag){
-		Check_MagData_Flag = MagData_Observer(InputData.MagDataPath, &MagDataProp, InputData.FastLoad_flag);
+		Check_MagData_Flag = MagData_Observer(InputData.MagDataPath, &MagDataProp, &InputData);
 		if(Check_MagData_Flag != true){
 			LogSystem::write(" ->-> Error in MagData!");
 			LogSystem::write("");
@@ -46,7 +46,7 @@ int main(int argc, char* argv[]){
 	NucDataProperties NucDataProp;
 	bool Check_NucData_Flag;
 	if(InputData.NucData_activate_flag){
-		Check_NucData_Flag = NucData_Observer(InputData.NucDataPath, &NucDataProp, InputData.FastLoad_flag);
+		Check_NucData_Flag = NucData_Observer(InputData.NucDataPath, &NucDataProp, &InputData);
 		if(Check_NucData_Flag != true){
 			LogSystem::write(" ->->Error in NucData!");
 			LogSystem::write("");
@@ -98,6 +98,40 @@ int main(int argc, char* argv[]){
 			LogSystem::write(" ->-> Error: StructData and RotData contain different numbers of entries!");
 			LogSystem::write("StructData entries: " + std::to_string(StructDataProp.Number_Of_Elements));
 			LogSystem::write("RotData entries: " + std::to_string(RotDataProp.Number_Of_Elements));
+			LogSystem::write("");
+			return 0;
+		}
+	}
+
+	int EffectiveObjectCount = 0;
+	if(InputData.MagData_activate_flag){
+		EffectiveObjectCount = MagDataProp.Number_Of_SubFolders;
+	}
+	if(InputData.NucData_activate_flag){
+		if(EffectiveObjectCount == 0){
+			EffectiveObjectCount = NucDataProp.Number_Of_SubFolders;
+		}else if(EffectiveObjectCount != NucDataProp.Number_Of_SubFolders){
+			LogSystem::write(" ->-> Error: MagData and NucData contain different effective object counts!");
+			LogSystem::write("MagData objects: " + std::to_string(MagDataProp.Number_Of_SubFolders));
+			LogSystem::write("NucData objects: " + std::to_string(NucDataProp.Number_Of_SubFolders));
+			LogSystem::write("");
+			return 0;
+		}
+	}
+	if(InputData.StructData_activate_flag && EffectiveObjectCount > 0){
+		if(StructDataProp.Number_Of_Elements != EffectiveObjectCount){
+			LogSystem::write(" ->-> Error: StructData entries do not match the effective object count!");
+			LogSystem::write("StructData entries: " + std::to_string(StructDataProp.Number_Of_Elements));
+			LogSystem::write("Effective object count: " + std::to_string(EffectiveObjectCount));
+			LogSystem::write("");
+			return 0;
+		}
+	}
+	if(InputData.RotData_activate_flag && EffectiveObjectCount > 0){
+		if(RotDataProp.Number_Of_Elements != EffectiveObjectCount){
+			LogSystem::write(" ->-> Error: RotData entries do not match the effective object count!");
+			LogSystem::write("RotData entries: " + std::to_string(RotDataProp.Number_Of_Elements));
+			LogSystem::write("Effective object count: " + std::to_string(EffectiveObjectCount));
 			LogSystem::write("");
 			return 0;
 		}

--- a/src/NuMagSANSInputTemplate.conf
+++ b/src/NuMagSANSInputTemplate.conf
@@ -29,6 +29,10 @@ StructData_activate = 1;  // activate structure data (activate: 1, deactivate: 0
 RotData_activate = 1;  // activate rotation data (activate: 1, deactivate: 0)
 
 FastLoad = 0;           // skip repeated MagData file dimension checks for faster import (activate: 1, deactivate: 0)
+NucData_ReplicationImport = 0; // replicate one local NucData object internally (activate: 1, deactivate: 0)
+NucData_NumberOfReplications = 1; // effective number of nuclear objects in replication import mode
+MagData_ReplicationImport = 0; // replicate one local MagData object internally (activate: 1, deactivate: 0)
+MagData_NumberOfReplications = 1; // effective number of magnetic objects in replication import mode
 Exclude_Zero_Moments = 0; // exclude magnetization data with zero magnetic moments (activate: 1, deactive: 0)
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

This PR adds a replication-import mode for reusable local real-space objects.

The new mode allows NuMagSANS to read one physical template object from disk and internally replicate it into the standard object-wise RAM/GPU data structure. This avoids writing many duplicated object folders for monodisperse or repeated-object ensembles, while keeping the existing scattering kernels unchanged.

## Main Changes

- Add new input options:
  - `MagData_ReplicationImport`
  - `MagData_NumberOfReplications`
  - `NucData_ReplicationImport`
  - `NucData_NumberOfReplications`
- Add replication-import support for `MagData`.
- Add analogous replication-import support for `NucData`.
- Extend the MagData/NucData explorers so they can virtualize one physical template object into an effective object count.
- Add dedicated replication read functions that read only `Object_1` and materialize the replicated object data in RAM.
- Add consistency checks for effective object counts against `StructData` and `RotData`.
- Update the Python facade and input template with the new parameters.
- Update documentation in `ParameterOverview.rst` and `SimulationScenarios.rst`.

## Design Notes

Replication import only changes the input/read layer.

It does not change:

- scattering kernels
- kernel selection logic
- GPU-side mathematical calculation
- StructData/RotData loop logic
- output organization

The replicated in-memory representation is intended to be equivalent to a fully materialized dataset with explicit `Object_1 ... Object_K` folders.

## Verification

Local checks:

- `git diff --check`
- Python syntax check for:
  - `NuMagSANS/NuMagSANS.py`
  - `examples/example1/NuMagSANSrun.py`
  - `examples/example2/NuMagSANSrun.py`

CUDA compilation and runtime examples should be verified on the HPC system.

closes #26 