### PR TITLE
added q_min feature

### DIFF
--- a/NuMagSANS/NuMagSANS.py
+++ b/NuMagSANS/NuMagSANS.py
@@ -135,6 +135,7 @@ class NuMagSANS:
         Number_Of_theta_Points=1000,
         Number_Of_r_Points=1000,
         Number_Of_alpha_Points=1000,
+        q_min=0.0,
         q_max=3.0,
         r_max=15.0,
 
@@ -246,6 +247,7 @@ class NuMagSANS:
             W("Number_Of_theta_Points", Number_Of_theta_Points)
             W("Number_Of_r_Points", Number_Of_r_Points)
             W("Number_Of_alpha_Points", Number_Of_alpha_Points)
+            W("q_min", q_min)
             W("q_max", q_max)
             W("r_max", r_max)
 

--- a/docs/GettingStarted/ParameterOverview.rst
+++ b/docs/GettingStarted/ParameterOverview.rst
@@ -343,8 +343,12 @@ Constant Parameters
     Number of angular sampling points in real space (correlation).
     Default value ``1000``
 
+``q_min``
+    Minimum scattering vector in Fourier space in units of :math:`\mathrm{nm}^{-1}`.
+    Default value ``0.0``
+
 ``q_max``
-    Maximum scattering vector in Fourier space in units of :math:`\mathrm{nm}^{-1}`
+    Maximum scattering vector in Fourier space in units of :math:`\mathrm{nm}^{-1}`.
     Default value ``3.0``
 
 ``r_max``

--- a/src/InputData/NuMagSANSlib_InputFileInterpreter.h
+++ b/src/InputData/NuMagSANSlib_InputFileInterpreter.h
@@ -183,6 +183,9 @@ struct InputFileData{
     /// Number of angular alpha points
     int N_alpha;
 
+    /// Minimum scattering vector magnitude [1/nm]
+    float q_min = 0.0;
+
     /// Maximum scattering vector magnitude [1/nm]
     float q_max;
 
@@ -622,6 +625,7 @@ bool ReadCSV__Input_File_Interpreter(string filename, InputFileData*InputData){
 	// float options ///////////////////////////////
 	std::vector<Option<float>> float_options = {
 
+		{"q_min", &InputData->q_min, false},
 		{"q_max", &InputData->q_max, true},
 		{"r_max", &InputData->r_max, true},
 		{"Scattering_Volume_V", &InputData->Scattering_Volume_V, true},
@@ -837,6 +841,20 @@ bool ReadCSV__Input_File_Interpreter(string filename, InputFileData*InputData){
 		ReplicationImport_CheckFlag = false;
 	}
 
+	bool ScatteringGrid_CheckFlag = true;
+	if(InputData->N_q <= 1){
+		LogSystem::write("Error: Number_Of_q_Points must be larger than one.");
+		ScatteringGrid_CheckFlag = false;
+	}
+	if(InputData->q_min < 0.0){
+		LogSystem::write("Error: q_min must be larger than or equal to zero.");
+		ScatteringGrid_CheckFlag = false;
+	}
+	if(InputData->q_max <= InputData->q_min){
+		LogSystem::write("Error: q_max must be larger than q_min.");
+		ScatteringGrid_CheckFlag = false;
+	}
+
 
 
 	LogSystem::write("##########################################################################################");
@@ -870,6 +888,6 @@ bool ReadCSV__Input_File_Interpreter(string filename, InputFileData*InputData){
 		LogSystem::write(" ->-> Error in input file!");
 	}
 
-	return ok && ReplicationImport_CheckFlag;
+	return ok && ReplicationImport_CheckFlag && ScatteringGrid_CheckFlag;
 
 }

--- a/src/NuMagSANSInputTemplate.conf
+++ b/src/NuMagSANSInputTemplate.conf
@@ -109,6 +109,7 @@ Number_Of_theta_Points = 1000;		// number of points for the azimuthal q-space co
 Number_Of_r_Points = 1000;		   	// number of points for the radial r-space coordinate
 Number_Of_alpha_Points = 1000;      // number of points for the azimuthal r-space coordinate
 
+q_min = 0.0;					// minimum value of the radial q-space coordinate in reciprocal nanometers (1/nm)
 q_max = 3.0;					// maximum value of the radial q-space coordinate in reciprocal nanometers (1/nm)
 r_max = 15.0;	        		// maxium value for the dimensionless radial real-space coordinate in nanometers (nm)
 

--- a/src/OutputData/SANSData/NuMagSANSlib_SANSData.h
+++ b/src/OutputData/SANSData/NuMagSANSlib_SANSData.h
@@ -39,6 +39,7 @@ struct ScatteringData {
 
 	float *Polarization; // polarization vector [Px, Py, Pz]
 
+	float *q_min;	// minimum q-value
 	float *q_max;	// maximum q-value
 	float *r_max;	// maximum r-value
 	
@@ -418,6 +419,7 @@ void allocate_ScatteringData_RAM(InputFileData *InputData,\
 	*SANSData->N_r = InputData->N_r;
 	*SANSData->N_alpha = InputData->N_alpha;
 
+	SANSData->q_min = (float*) malloc(sizeof(float));
 	SANSData->q_max = (float*) malloc(sizeof(float));
 	SANSData->r_max = (float*) malloc(sizeof(float));
 	SANSData->dq = (float*) malloc(sizeof(float));
@@ -425,9 +427,10 @@ void allocate_ScatteringData_RAM(InputFileData *InputData,\
 	SANSData->dr = (float*) malloc(sizeof(float));
 	SANSData->dalpha = (float*) malloc(sizeof(float));
 	
+	*SANSData->q_min = InputData->q_min;
 	*SANSData->q_max = InputData->q_max;
 	*SANSData->r_max = InputData->r_max;
-	*SANSData->dq = (InputData->q_max)/((float) InputData->N_q - 1.0);
+	*SANSData->dq = (InputData->q_max - InputData->q_min)/((float) InputData->N_q - 1.0);
 	*SANSData->dr = (InputData->r_max)/((float) InputData->N_r - 1.0);
 	*SANSData->dtheta = (2.0*M_PI)/((float) InputData->N_theta - 1.0);
 	*SANSData->dalpha = (2.0*M_PI)/((float) InputData->N_alpha - 1.0);
@@ -488,7 +491,7 @@ void allocate_ScatteringData_RAM(InputFileData *InputData,\
 
 	for(unsigned int i = 0; i < InputData->N_q; i++){
 	
-		SANSData->q_1D[i] = i * (*SANSData->dq);
+		SANSData->q_1D[i] = InputData->q_min + i * (*SANSData->dq);
 		SANSData->S_Nuc_1D_unpolarized[i] = 0.0;
 		SANSData->S_Mag_1D_unpolarized[i] = 0.0;
 		SANSData->S_Mag_1D_polarized[i] = 0.0;
@@ -665,9 +668,11 @@ void allocate_ScatteringData_GPU(ScatteringData *SANSData, \
 	cudaMemcpy(SANSData_gpu->N_r, SANSData->N_r, sizeof(unsigned int), cudaMemcpyHostToDevice);
 	cudaMemcpy(SANSData_gpu->N_alpha, SANSData->N_alpha, sizeof(unsigned int), cudaMemcpyHostToDevice);
 
+	cudaMalloc(&SANSData_gpu->q_min, sizeof(float));
 	cudaMalloc(&SANSData_gpu->q_max, sizeof(float));
 	cudaMalloc(&SANSData_gpu->r_max, sizeof(float));
 
+	cudaMemcpy(SANSData_gpu->q_min, SANSData->q_min, sizeof(float), cudaMemcpyHostToDevice);
 	cudaMemcpy(SANSData_gpu->q_max, SANSData->q_max, sizeof(float), cudaMemcpyHostToDevice);
 	cudaMemcpy(SANSData_gpu->r_max, SANSData->r_max, sizeof(float), cudaMemcpyHostToDevice);
 
@@ -1304,6 +1309,7 @@ void free_ScatteringData(ScatteringData *SANSData, \
 	free(SANSData->N_r);
 	free(SANSData->N_alpha);
 
+	free(SANSData->q_min);
 	free(SANSData->q_max);
 	free(SANSData->r_max);
 	free(SANSData->dq);
@@ -1417,6 +1423,7 @@ void free_ScatteringData(ScatteringData *SANSData, \
 	cudaFree(SANSData_gpu->N_alpha);
 	cudaDeviceSynchronize();
 
+	cudaFree(SANSData_gpu->q_min);
 	cudaFree(SANSData_gpu->q_max);
 	cudaFree(SANSData_gpu->r_max);
 	cudaFree(SANSData_gpu->dq);


### PR DESCRIPTION
## Summary

This PR adds a `q_min` input option for the Fourier-space q grid.

Previously, NuMagSANS always generated the radial q grid from `0` to `q_max`. With this update, users can define an explicit lower q bound while keeping the existing default behavior.

## Main Changes

- Add `q_min` to `InputFileData`.
- Parse optional `q_min` from the input configuration.
- Keep backward compatibility by defaulting `q_min = 0.0` when it is not provided.
- Store `q_min` in `ScatteringData`, analogously to `q_max`.
- Copy `q_min` to GPU memory and free it consistently.
- Generate the q grid as:

```cpp
dq = (q_max - q_min) / (N_q - 1);
q_1D[i] = q_min + i * dq;
```

- Update the Python facade so `write_config(...)` writes `q_min`.
- Update `NuMagSANSInputTemplate.conf`.
- Update the parameter documentation.

## Validation

The input interpreter now checks that:

- `Number_Of_q_Points > 1`
- `q_min >= 0`
- `q_max > q_min`

## Design Notes

The scattering kernels do not need to change. They already consume the precomputed q arrays from `ScatteringData`, so the new q range is handled entirely during q-grid initialization.

## Local Checks

- `git diff --check`
- Python AST syntax check for:
  - `NuMagSANS/NuMagSANS.py`
  - `examples/example1/NuMagSANSrun.py`
  - `examples/example2/NuMagSANSrun.py`

CUDA compilation and runtime examples should be verified on the HPC system.